### PR TITLE
Add core domain models

### DIFF
--- a/backend/internal/domain/author.go
+++ b/backend/internal/domain/author.go
@@ -1,0 +1,36 @@
+package domain
+
+// Author represents a person who contributed to a publication.
+//
+// It contains the author's personal name components, institutional
+// affiliation, and an optional ORCID identifier used to uniquely
+// identify researchers.
+type Author struct {
+	// NameFirst is the author's given (first) name.
+	NameFirst string `json:"name-first"`
+
+	// NameMiddle is the author's middle name or middle initials.
+	// It may be empty if the author does not use a middle name.
+	NameMiddle string `json:"name-middle"`
+
+	// NameLast is the author's family or last name.
+	NameLast string `json:"name-last"`
+
+	// Affiliation specifies the institution or organization
+	// the author was associated with at the time of publication.
+	Affiliation string `json:"affiliation"`
+
+	// ORCID is the author's ORCID identifier, a persistent
+	// digital identifier for researchers (e.g. "0000-0002-1825-0097").
+	// It may be empty if the author has no ORCID.
+	ORCID string `json:"orcid"`
+}
+
+// FullName returns the author's full name assembled from
+// the available name components.
+func (a Author) FullName() string {
+	if a.NameMiddle != "" {
+		return a.NameFirst + " " + a.NameMiddle + " " + a.NameLast
+	}
+	return a.NameFirst + " " + a.NameLast
+}

--- a/backend/internal/domain/doc.go
+++ b/backend/internal/domain/doc.go
@@ -1,0 +1,2 @@
+// Package domain defines the core domain models used by the application.
+package domain

--- a/backend/internal/domain/metadata.go
+++ b/backend/internal/domain/metadata.go
@@ -1,0 +1,60 @@
+package domain
+
+// Metadata contains bibliographic and provenance information
+// describing where and how a publication was published.
+//
+// It includes identifiers such as DOI and ISBN, publication
+// details like volume and issue, licensing information, and
+// metadata about the source from which this information was
+// retrieved (e.g., CrossRef or IEEE).
+type Metadata struct {
+	// Publisher is the organization responsible for publishing
+	// the work (e.g., "IEEE", "ACM", or "Springer").
+	Publisher string `json:"publisher"`
+
+	// PublishedIn specifies the container in which the work
+	// appears, such as a journal, book, or conference proceedings.
+	PublishedIn string `json:"published-in"`
+
+	// Pages indicates the page number or page range of the work
+	// within the publication (e.g. "11" or "42-53").
+	Pages string `json:"pages"`
+
+	// Volume is the volume number of the journal or proceedings.
+	Volume string `json:"volume"`
+
+	// Issue is the issue number within the volume.
+	Issue string `json:"issue"`
+
+	// ISBN lists International Standard Book Numbers associated
+	// with the publication, typically used for books or proceedings.
+	ISBN []string `json:"ISBN"`
+
+	// DOI is the Digital Object Identifier that uniquely identifies
+	// the publication (e.g. "10.1145/1234567.1234568").
+	DOI string `json:"DOI"`
+
+	// References contains external references related to the work,
+	// typically URLs or URIs pointing to additional resources.
+	References []string `json:"references"`
+
+	// License specifies the license under which the work is
+	// distributed, expressed as an SPDX license identifier.
+	License string `json:"license"`
+
+	// Copyright contains the copyright statement associated
+	// with the publication.
+	Copyright string `json:"copyright"`
+
+	// Funding describes funding sources or grants that supported
+	// the work.
+	Funding string `json:"funding"`
+
+	// DataSource indicates the origin of the metadata, such as
+	// crossref.org, manual user input, etc.
+	DataSource string `json:"data-source"`
+
+	// DataSourceTimestamp records when the metadata was retrieved
+	// or generated, expressed as an ISO 8601 timestamp.
+	DataSourceTimestamp string `json:"data-source-timestamp"`
+}

--- a/backend/internal/domain/paper.go
+++ b/backend/internal/domain/paper.go
@@ -1,0 +1,40 @@
+package domain
+
+// Paper represents a scientific publication with bibliographic metadata,
+// authors, and associated documents such as PDFs.
+type Paper struct {
+	// Title is the full title of the publication.
+	Title string `json:"title"`
+
+	// TitleShort is an abbreviated version of the title used for citations.
+	TitleShort string `json:"title-short"`
+
+	// Authors lists all authors who contributed to the publication.
+	Authors []Author `json:"authors"`
+
+	// PublicationYear is the year the work was published or made public.
+	PublicationYear string `json:"publication-year"`
+
+	// PublicationStatus describes the publication state
+	// (e.g., "published", "preprint", or "retracted").
+	PublicationStatus string `json:"publication-status"`
+
+	// PublicationStatusTimestamp records when the publication status was changed
+	// or generated, expressed as an ISO 8601 timestamp.
+	PublicationStatusTimestamp string `json:"publication-status-timestamp"`
+
+	// Abstract contains the summary of the publication.
+	Abstract string `json:"abstract"`
+
+	// Keywords contains search keywords associated with the paper.
+	Keywords string `json:"keywords"`
+
+	// Type specifies the publication type (e.g. "journal" or "conference").
+	Type string `json:"type"`
+
+	// PDFs contains URIs pointing to PDF versions of the paper.
+	PDFs []string `json:"pdfs"`
+
+	// Metadata contains detailed bibliographic metadata for the publication.
+	Metadata Metadata `json:"metadata"`
+}


### PR DESCRIPTION
This PR add the first version of the core domain models for the application: Paper, Author, and Metadata.

Closes issue #6 