### PR TITLE
Refactor paper by uuid path

### DIFF
--- a/backend/internal/integration/paper_integration_test.go
+++ b/backend/internal/integration/paper_integration_test.go
@@ -28,7 +28,7 @@ func TestIntegrationListPapers(t *testing.T) {
 
 func TestIntegrationGetPaperByUUID(t *testing.T) {
 	uuid := "a4b065f1-1b88-4f50-a7fe-1177f3489fcf"
-	endpoint := testAPIPath + "/api/papers/uuid/" + uuid
+	endpoint := testAPIPath + "/api/papers/" + uuid
 	resp := doGetRequest(t, endpoint)
 	defer resp.Body.Close()
 

--- a/backend/internal/paper/http/routes.go
+++ b/backend/internal/paper/http/routes.go
@@ -1,3 +1,4 @@
+// Package http provides HTTP routes and handlers for paper resources.
 package http
 
 import (
@@ -16,7 +17,7 @@ func AddPaperRoute(
 	defaultMiddle := middleware.NewDefault(logger)
 
 	mux.Handle(http.MethodGet+" /papers", defaultMiddle(handleListOrSearchPapers(logger, paperService)))
-	mux.Handle(http.MethodGet+" /papers/uuid/{uuid...}", defaultMiddle(handleGetPaperByUUID(logger, paperService)))
+	mux.Handle(http.MethodGet+" /papers/{uuid}", defaultMiddle(handleGetPaperByUUID(logger, paperService)))
 	mux.Handle(http.MethodGet+" /papers/doi/{doi...}", defaultMiddle(handleGetPaperByDOI(logger, paperService)))
 
 	mux.Handle(http.MethodDelete+" /papers/doi/{doi...}", defaultMiddle(handleDeletePaper(logger, paperService)))


### PR DESCRIPTION
This PR adjusts the path to get a paper by ID from `/papers/uuid/{uuid}` to `/papers/{uuid}`.
This is more align with common API conventions.