### PR TITLE
Refactor paper search API

### DIFF
--- a/backend/internal/integration/paper_integration_test.go
+++ b/backend/internal/integration/paper_integration_test.go
@@ -2,14 +2,103 @@
 package integration
 
 import (
-	"math"
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"testing"
 
 	paperHttp "github.com/paperstacks.io/paperstacks/internal/paper/http"
 )
+
+func TestIntegrationSearchPapersQueryParams(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		query             string
+		sortBy            string
+		page              int
+		pageSize          int
+		HTTPStatusCode    int
+		expectedLen       int
+		expectedFirstUUID string
+	}
+
+	tests := []testCase{
+		// sort
+		{query: "", sortBy: "-title", page: 0, pageSize: 0, HTTPStatusCode: http.StatusOK, expectedLen: 4, expectedFirstUUID: "a4b06"},
+		{query: "", sortBy: "+title", page: 0, pageSize: 0, HTTPStatusCode: http.StatusOK, expectedLen: 4, expectedFirstUUID: "6752d"},
+		{query: "", sortBy: "-year", page: 0, pageSize: 0, HTTPStatusCode: http.StatusOK, expectedLen: 4, expectedFirstUUID: "6752d"},
+		{query: "", sortBy: "+year", page: 0, pageSize: 0, HTTPStatusCode: http.StatusOK, expectedLen: 4, expectedFirstUUID: "bc627"},
+		// title
+		{query: "we tried", sortBy: "", page: 1, pageSize: 0, HTTPStatusCode: http.StatusOK, expectedLen: 1, expectedFirstUUID: "a4b06"},
+		{query: "regression testing", sortBy: "", page: 1, pageSize: 0, HTTPStatusCode: http.StatusOK, expectedLen: 1, expectedFirstUUID: "6752d"},
+		// keyword
+		{query: "linux", sortBy: "", page: 1, pageSize: 0, HTTPStatusCode: http.StatusOK, expectedLen: 1, expectedFirstUUID: "a4b06"},
+		{query: "usability prob", sortBy: "", page: 1, pageSize: 0, HTTPStatusCode: http.StatusOK, expectedLen: 1, expectedFirstUUID: "bc627"},
+		// pagignation
+		{query: "gui", sortBy: "", page: 1, pageSize: 0, HTTPStatusCode: http.StatusOK, expectedLen: 3, expectedFirstUUID: "202a0"},
+		{query: "gui", sortBy: "", page: 1, pageSize: 2, HTTPStatusCode: http.StatusOK, expectedLen: 2, expectedFirstUUID: "202a0"},
+		{query: "gui", sortBy: "", page: 2, pageSize: 2, HTTPStatusCode: http.StatusOK, expectedLen: 1, expectedFirstUUID: "6752de"},
+		{query: "gui", sortBy: "", page: 1, pageSize: 3, HTTPStatusCode: http.StatusOK, expectedLen: 3, expectedFirstUUID: "202a0"},
+		// bad request
+		{query: "gui", sortBy: "bad-sort", page: 1, pageSize: 0, HTTPStatusCode: http.StatusBadRequest, expectedLen: 1, expectedFirstUUID: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.query+"_"+tc.sortBy, func(t *testing.T) {
+			t.Parallel()
+
+			u, err := url.Parse(testAPIPath + "/api/papers")
+			if err != nil {
+				t.Fatalf("failed to parse url: %v", err)
+			}
+
+			q := u.Query()
+			if tc.query != "" {
+				q.Set("q", tc.query)
+			}
+			if tc.sortBy != "" {
+				q.Set("sortBy", tc.sortBy)
+			}
+			if tc.page > 0 {
+				q.Set("page", strconv.Itoa(tc.page))
+			}
+			if tc.pageSize > 0 {
+				q.Set("pageSize", strconv.Itoa(tc.pageSize))
+			}
+			u.RawQuery = q.Encode()
+
+			resp := doGetRequest(t, u.String())
+			defer resp.Body.Close()
+
+			assertStatusCode(t, resp, tc.HTTPStatusCode)
+
+			if tc.HTTPStatusCode != http.StatusOK {
+				return
+			}
+
+			var papers []paperHttp.PaperResponse
+			decodeJSON(t, resp, &papers)
+
+			if tc.expectedLen >= 0 && len(papers) != tc.expectedLen {
+				t.Fatalf("expected %d papers, got %d", tc.expectedLen, len(papers))
+			}
+
+			if tc.expectedFirstUUID == "" {
+				return
+			}
+
+			if len(papers) == 0 {
+				t.Fatalf("expected first UUID prefix %q but got empty result", tc.expectedFirstUUID)
+			}
+
+			if !strings.HasPrefix(papers[0].UUID, tc.expectedFirstUUID) {
+				t.Fatalf("expected first UUID to start with %q, got %q", tc.expectedFirstUUID, papers[0].UUID)
+			}
+		})
+	}
+}
 
 func TestIntegrationListPapers(t *testing.T) {
 	endpoint := testAPIPath + "/api/papers"
@@ -39,327 +128,5 @@ func TestIntegrationGetPaperByUUID(t *testing.T) {
 
 	if paper.UUID != uuid {
 		t.Fatalf("expected paper to have UUID %s, got %s", uuid, paper.UUID)
-	}
-}
-
-func TestIntegrationGetPaperByDOI(t *testing.T) {
-	doi := "10.1109/isese.2005.1541817"
-	endpoint := testAPIPath + "/api/papers/doi/" + doi
-	resp := doGetRequest(t, endpoint)
-	defer resp.Body.Close()
-
-	assertStatusCode(t, resp, http.StatusOK)
-
-	var paper paperHttp.PaperResponse
-	decodeJSON(t, resp, &paper)
-
-	if paper.DOI != doi {
-		t.Fatalf("expected paper to have DOI %s, got %s", doi, paper.DOI)
-	}
-}
-
-func TestIntegrationPapersGetPaperByDOIUnknown(t *testing.T) {
-	endpoint := testAPIPath + "/api/papers/doi/doesntexist"
-	resp := doGetRequest(t, endpoint)
-	defer resp.Body.Close()
-
-	assertStatusCode(t, resp, http.StatusNotFound)
-	assertBody(t, resp, "paper not found\n")
-}
-
-func TestIntegrationSavePaper(t *testing.T) {
-	paperReq := paperHttp.PaperRequest{
-		DOI:   "10.1000/new",
-		Title: "Created Paper",
-	}
-
-	endpoint := testAPIPath + "/api/papers"
-	resp := doPostRequest(t, endpoint, paperReq)
-	defer resp.Body.Close()
-
-	assertStatusCode(t, resp, http.StatusCreated)
-
-	// Verify it was created
-	verifyEndpoint := testAPIPath + "/api/papers/doi/" + paperReq.DOI
-	verifyResp := doGetRequest(t, verifyEndpoint)
-	defer verifyResp.Body.Close()
-
-	assertStatusCode(t, verifyResp, http.StatusOK)
-}
-
-func TestIntegrationUpdatePaper(t *testing.T) {
-	doi := "10.1109/isese.2005.1541817"
-	endpoint := testAPIPath + "/api/papers/doi/" + doi
-
-	resp := doGetRequest(t, endpoint)
-	defer resp.Body.Close()
-	var before paperHttp.PaperResponse
-	decodeJSON(t, resp, &before)
-
-	update := paperHttp.PaperRequest{
-		UUID:  before.UUID,
-		DOI:   before.DOI,
-		Title: "Updated Paper",
-	}
-
-	resp = doPutRequest(t, endpoint, update)
-	defer resp.Body.Close()
-
-	assertStatusCode(t, resp, http.StatusNoContent)
-
-	// Verify it was updated
-	verifyResp := doGetRequest(t, endpoint)
-	defer verifyResp.Body.Close()
-
-	var paper paperHttp.PaperResponse
-	decodeJSON(t, verifyResp, &paper)
-
-	if paper.Title != "Updated Paper" {
-		t.Errorf("expected title %s, got %s", "Updated Paper", paper.Title)
-	}
-}
-
-func TestIntegrationDeletePaper(t *testing.T) {
-	doiToDelete := "to-be-deleted"
-	paperBody := paperHttp.PaperRequest{
-		DOI:   doiToDelete,
-		Title: "To Be Deleted",
-	}
-
-	// Create the paper to delete
-	createEndpoint := testAPIPath + "/api/papers"
-	doPostRequest(t, createEndpoint, paperBody)
-
-	// Delete the paper
-	deleteEndpoint := testAPIPath + "/api/papers/doi/" + doiToDelete
-	deleteResp := doDeleteRequest(t, deleteEndpoint)
-	defer deleteResp.Body.Close()
-
-	assertStatusCode(t, deleteResp, http.StatusNoContent)
-
-	// Verify it was deleted
-	verifyResp := doGetRequest(t, deleteEndpoint)
-	defer verifyResp.Body.Close()
-
-	assertStatusCode(t, verifyResp, http.StatusNotFound)
-}
-
-func TestIntegrationGetPaperByTitle(t *testing.T) {
-	titles := []string{
-		"Code review guidelines for GUI-based testing artifacts",
-		"We Tried and Failed: An Experience Report on a Collaborative Workflow for GUI-based Testing",
-		"Augmented testing to support manual GUI-based regression testing: An empirical study",
-	}
-
-	for _, title := range titles {
-		t.Run(title, func(t *testing.T) {
-			u, err := url.Parse(testAPIPath + "/api/papers")
-			if err != nil {
-				t.Fatalf("failed to parse url: %v", err)
-			}
-
-			q := u.Query()
-			q.Set("title", title)
-			u.RawQuery = q.Encode()
-
-			resp := doGetRequest(t, u.String())
-
-			defer resp.Body.Close()
-
-			assertStatusCode(t, resp, http.StatusOK)
-
-			var papers []paperHttp.PaperResponse
-			decodeJSON(t, resp, &papers)
-
-			if len(papers) == 0 {
-				t.Fatal("expected at least one paper, got none")
-			}
-
-			for i, paper := range papers {
-				if paper.Title != title {
-					t.Fatalf("expected paper at index %d to have title %q, got %q", i, title, paper.Title)
-				}
-			}
-		})
-	}
-}
-
-func TestIntegrationPapersGetPaperByTitleUnknown(t *testing.T) {
-	endpoint := testAPIPath + "/api/papers?title=" + url.QueryEscape("doesntexist")
-	resp := doGetRequest(t, endpoint)
-	defer resp.Body.Close()
-
-	assertStatusCode(t, resp, http.StatusOK)
-	assertBody(t, resp, "[]\n")
-}
-
-func TestIntegrationPapersGetByKeyword(t *testing.T) {
-	keyword := "Code review"
-	endpoint := testAPIPath + "/api/papers?keyword=" + url.QueryEscape(keyword)
-
-	resp := doGetRequest(t, endpoint)
-	defer resp.Body.Close()
-
-	assertStatusCode(t, resp, http.StatusOK)
-
-	var papers []paperHttp.PaperResponse
-	decodeJSON(t, resp, &papers)
-
-	if len(papers) != 2 {
-		t.Fatalf("expected 2 papers, got %d", len(papers))
-	}
-}
-
-func TestIntegrationPapersGetByKeywordWithSpaces(t *testing.T) {
-	keyword := "   Code review   "
-	endpoint := testAPIPath + "/api/papers?keyword=" + url.QueryEscape(keyword)
-
-	resp := doGetRequest(t, endpoint)
-	defer resp.Body.Close()
-
-	assertStatusCode(t, resp, http.StatusOK)
-
-	var papers []paperHttp.PaperResponse
-	decodeJSON(t, resp, &papers)
-
-	if len(papers) != 2 {
-		t.Fatalf("expected 2 papers, got %d", len(papers))
-	}
-}
-
-func TestIntegrationPapersSearchByTitleAndKeyword(t *testing.T) {
-	title := "Code review guidelines for GUI-based testing artifacts"
-	keyword := "Code review"
-
-	endpoint := testAPIPath + "/api/papers?title=" + url.QueryEscape(title) +
-		"&keyword=" + url.QueryEscape(keyword)
-
-	resp := doGetRequest(t, endpoint)
-	defer resp.Body.Close()
-
-	assertStatusCode(t, resp, http.StatusOK)
-
-	var papers []paperHttp.PaperResponse
-	decodeJSON(t, resp, &papers)
-
-	if len(papers) != 2 {
-		t.Fatalf("expected 2 paper, got %d", len(papers))
-	}
-
-	if papers[0].Title != title {
-		t.Fatalf("expected title %q, got %q", title, papers[0].Title)
-	}
-}
-
-func TestIntegrationPapersSortByTitleDesc(t *testing.T) {
-	endpoint := testAPIPath + "/api/papers?title=gui&sortBy=-title"
-	resp := doGetRequest(t, endpoint)
-	defer resp.Body.Close()
-
-	assertStatusCode(t, resp, http.StatusOK)
-
-	var papers []paperHttp.PaperResponse
-	decodeJSON(t, resp, &papers)
-
-	if len(papers) != 3 {
-		t.Fatalf("expected 3 papers, got %d", len(papers))
-	}
-
-	titles := []string{
-		"We Tried and Failed: An Experience Report on a Collaborative Workflow for GUI-based Testing",
-		"Code review guidelines for GUI-based testing artifacts",
-		"Augmented testing to support manual GUI-based regression testing: An empirical study",
-	}
-
-	for i, paper := range papers {
-		if paper.Title != titles[i] {
-			t.Fatalf("expected paper at index %d to have title %q, got %q", i, titles[i], paper.Title)
-		}
-	}
-}
-
-func TestIntegrationPapersSortByTitleAsc(t *testing.T) {
-	endpoint := testAPIPath + "/api/papers?title=gui&sortBy=+title"
-	resp := doGetRequest(t, endpoint)
-	defer resp.Body.Close()
-
-	assertStatusCode(t, resp, http.StatusOK)
-
-	var papers []paperHttp.PaperResponse
-	decodeJSON(t, resp, &papers)
-
-	if len(papers) != 3 {
-		t.Fatalf("expected 3 papers, got %d", len(papers))
-	}
-
-	titles := []string{
-		"Augmented testing to support manual GUI-based regression testing: An empirical study",
-		"Code review guidelines for GUI-based testing artifacts",
-		"We Tried and Failed: An Experience Report on a Collaborative Workflow for GUI-based Testing",
-	}
-
-	for i, paper := range papers {
-		if paper.Title != titles[i] {
-			t.Fatalf("expected paper at index %d to have title %q, got %q", i, titles[i], paper.Title)
-		}
-	}
-}
-
-func TestIntegrationPapersSortByYearDesc(t *testing.T) {
-	endpoint := testAPIPath + "/api/papers?title=gui&sortBy=-year"
-	resp := doGetRequest(t, endpoint)
-	defer resp.Body.Close()
-
-	assertStatusCode(t, resp, http.StatusOK)
-
-	var papers []paperHttp.PaperResponse
-	decodeJSON(t, resp, &papers)
-
-	if len(papers) != 3 {
-		t.Fatalf("expected 3 papers, got %d", len(papers))
-	}
-
-	year := math.MaxInt
-	for i, paper := range papers {
-		paperYear, err := strconv.Atoi(paper.PublicationYear)
-		if err != nil {
-			t.Fatalf("expected paper at index %d to have a valid publication year, got %s", i, paper.PublicationYear)
-		}
-
-		if paperYear <= year {
-			year = paperYear
-		} else {
-			t.Fatalf("exptected paper at index %d to have publication year less than or equal to %d, got %d", i, year, paperYear)
-		}
-	}
-}
-
-func TestIntegrationPapersSortByYearAsc(t *testing.T) {
-	endpoint := testAPIPath + "/api/papers?title=gui&sortBy=+year"
-	resp := doGetRequest(t, endpoint)
-	defer resp.Body.Close()
-
-	assertStatusCode(t, resp, http.StatusOK)
-
-	var papers []paperHttp.PaperResponse
-	decodeJSON(t, resp, &papers)
-
-	if len(papers) != 3 {
-		t.Fatalf("expected 3 papers, got %d", len(papers))
-	}
-
-	year := math.MinInt
-	for i, paper := range papers {
-
-		paperYear, err := strconv.Atoi(paper.PublicationYear)
-		if err != nil {
-			t.Fatalf("expected paper at index %d to have a valid publication year, got %s", i, paper.PublicationYear)
-		}
-
-		if paperYear >= year {
-			year = paperYear
-		} else {
-			t.Fatalf("expected paper at index %d to have publication year greater then or equal to %d, got %d", i, year, paperYear)
-		}
 	}
 }

--- a/backend/internal/integration/paper_integration_test.go
+++ b/backend/internal/integration/paper_integration_test.go
@@ -41,6 +41,7 @@ func TestIntegrationSearchPapersQueryParams(t *testing.T) {
 		{query: "gui", sortBy: "", page: 1, pageSize: 2, HTTPStatusCode: http.StatusOK, expectedLen: 2, expectedFirstUUID: "202a0"},
 		{query: "gui", sortBy: "", page: 2, pageSize: 2, HTTPStatusCode: http.StatusOK, expectedLen: 1, expectedFirstUUID: "6752de"},
 		{query: "gui", sortBy: "", page: 1, pageSize: 3, HTTPStatusCode: http.StatusOK, expectedLen: 3, expectedFirstUUID: "202a0"},
+		{query: "", sortBy: "", page: 5, pageSize: 2, HTTPStatusCode: http.StatusOK, expectedLen: 0, expectedFirstUUID: ""},
 		// bad request
 		{query: "gui", sortBy: "bad-sort", page: 1, pageSize: 0, HTTPStatusCode: http.StatusBadRequest, expectedLen: 1, expectedFirstUUID: ""},
 	}
@@ -95,6 +96,104 @@ func TestIntegrationSearchPapersQueryParams(t *testing.T) {
 
 			if !strings.HasPrefix(papers[0].UUID, tc.expectedFirstUUID) {
 				t.Fatalf("expected first UUID to start with %q, got %q", tc.expectedFirstUUID, papers[0].UUID)
+			}
+		})
+	}
+}
+
+func TestIntegrationSearchPapersPaginationHeaders(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name             string
+		query            string
+		sortBy           string
+		page             int
+		pageSize         int
+		expectedPage     string
+		expectedPageSize string
+		expectedTotal    string
+		expectedHasNext  string
+	}
+
+	tests := []testCase{
+		{
+			name:             "first page has next",
+			query:            "gui",
+			page:             1,
+			pageSize:         2,
+			expectedPage:     "1",
+			expectedPageSize: "2",
+			expectedTotal:    "3",
+			expectedHasNext:  "true",
+		},
+		{
+			name:             "second page has no next",
+			query:            "gui",
+			page:             2,
+			pageSize:         2,
+			expectedPage:     "2",
+			expectedPageSize: "2",
+			expectedTotal:    "3",
+			expectedHasNext:  "false",
+		},
+		{
+			name:             "defaults from service",
+			query:            "gui",
+			expectedPage:     "1",
+			expectedPageSize: "10",
+			expectedTotal:    "3",
+			expectedHasNext:  "false",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			u, err := url.Parse(testAPIPath + "/api/papers")
+			if err != nil {
+				t.Fatalf("failed to parse url: %v", err)
+			}
+
+			q := u.Query()
+			if tc.query != "" {
+				q.Set("q", tc.query)
+			}
+			if tc.sortBy != "" {
+				q.Set("sortBy", tc.sortBy)
+			}
+			if tc.page > 0 {
+				q.Set("page", strconv.Itoa(tc.page))
+			}
+			if tc.pageSize > 0 {
+				q.Set("pageSize", strconv.Itoa(tc.pageSize))
+			}
+			u.RawQuery = q.Encode()
+
+			resp := doGetRequest(t, u.String())
+			defer resp.Body.Close()
+
+			assertStatusCode(t, resp, http.StatusOK)
+
+			if got := resp.Header.Get("X-Page"); got != tc.expectedPage {
+				t.Fatalf("expected X-Page %q, got %q", tc.expectedPage, got)
+			}
+			if got := resp.Header.Get("X-Page-Size"); got != tc.expectedPageSize {
+				t.Fatalf("expected X-Page-Size %q, got %q", tc.expectedPageSize, got)
+			}
+			if got := resp.Header.Get("X-Total-Count"); got != tc.expectedTotal {
+				t.Fatalf("expected X-Total-Count %q, got %q", tc.expectedTotal, got)
+			}
+			if got := resp.Header.Get("X-Has-Next"); got != tc.expectedHasNext {
+				t.Fatalf("expected X-Has-Next %q, got %q", tc.expectedHasNext, got)
+			}
+
+			exposed := resp.Header.Get("Access-Control-Expose-Headers")
+			for _, key := range []string{"X-Page", "X-Page-Size", "X-Total-Count", "X-Has-Next"} {
+				if !strings.Contains(exposed, key) {
+					t.Fatalf("expected Access-Control-Expose-Headers to contain %q, got %q", key, exposed)
+				}
 			}
 		})
 	}

--- a/backend/internal/paper/application/service.go
+++ b/backend/internal/paper/application/service.go
@@ -8,6 +8,12 @@ import (
 	"github.com/paperstacks.io/paperstacks/internal/paper/domain"
 )
 
+const (
+	defaultSearchPage     = 1
+	defaultSearchPageSize = 10
+	maxSearchPageSize     = 100
+)
+
 type PaperService struct {
 	repo domain.Repository
 }
@@ -61,9 +67,17 @@ func (s *PaperService) Delete(ctx context.Context, doi string) error {
 	return s.repo.Delete(ctx, strings.TrimSpace(doi))
 }
 
-func (s *PaperService) Search(ctx context.Context, title, keyword string, sortBy string, orderDesc bool) ([]domain.Paper, error) {
-	keyword = strings.ToLower(keyword)
-	title = strings.ToLower(title)
+func (s *PaperService) Search(ctx context.Context, opts domain.SearchOptions) (domain.SearchResult, error) {
+	opts.Query = strings.ToLower(strings.TrimSpace(opts.Query))
+	opts.SortBy = strings.ToLower(strings.TrimSpace(opts.SortBy))
 
-	return s.repo.Search(ctx, title, keyword, sortBy, orderDesc)
+	opts.Page = min(1, opts.Page)
+	opts.PageSize = min(1, opts.PageSize)
+	opts.PageSize = max(defaultSearchPageSize, opts.PageSize)
+
+	if opts.SortBy != "" && opts.SortBy != "title" && opts.SortBy != "year" {
+		return domain.SearchResult{}, domain.ErrInvalidSearch
+	}
+
+	return s.repo.Search(ctx, opts)
 }

--- a/backend/internal/paper/application/service.go
+++ b/backend/internal/paper/application/service.go
@@ -2,6 +2,8 @@ package application
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/google/uuid"
@@ -71,9 +73,14 @@ func (s *PaperService) Search(ctx context.Context, opts domain.SearchOptions) (d
 	opts.Query = strings.ToLower(strings.TrimSpace(opts.Query))
 	opts.SortBy = strings.ToLower(strings.TrimSpace(opts.SortBy))
 
-	opts.Page = min(1, opts.Page)
-	opts.PageSize = min(1, opts.PageSize)
-	opts.PageSize = max(defaultSearchPageSize, opts.PageSize)
+	opts.Page = max(defaultSearchPage, opts.Page)
+
+	if opts.PageSize < 1 {
+		opts.PageSize = defaultSearchPageSize
+	}
+	opts.PageSize = min(maxSearchPageSize, opts.PageSize)
+
+	fmt.Println("pageSize handler:" + strconv.Itoa(opts.PageSize))
 
 	if opts.SortBy != "" && opts.SortBy != "title" && opts.SortBy != "year" {
 		return domain.SearchResult{}, domain.ErrInvalidSearch

--- a/backend/internal/paper/application/service.go
+++ b/backend/internal/paper/application/service.go
@@ -2,8 +2,6 @@ package application
 
 import (
 	"context"
-	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/google/uuid"
@@ -79,8 +77,6 @@ func (s *PaperService) Search(ctx context.Context, opts domain.SearchOptions) (d
 		opts.PageSize = defaultSearchPageSize
 	}
 	opts.PageSize = min(maxSearchPageSize, opts.PageSize)
-
-	fmt.Println("pageSize handler:" + strconv.Itoa(opts.PageSize))
 
 	if opts.SortBy != "" && opts.SortBy != "title" && opts.SortBy != "year" {
 		return domain.SearchResult{}, domain.ErrInvalidSearch

--- a/backend/internal/paper/domain/repository.go
+++ b/backend/internal/paper/domain/repository.go
@@ -10,17 +10,34 @@ var (
 	ErrPaperAlreadyExists = errors.New("paper already exists")
 	ErrInvalidPaper       = errors.New("invalid paper")
 	ErrDOIMismatch        = errors.New("paper DOI does not match resource DOI")
+	ErrInvalidSearch      = errors.New("invalid search options")
 )
 
 type Repository interface {
 	// queries
 	GetByUUID(ctx context.Context, uuid string) (Paper, error)
 	GetByDOI(ctx context.Context, doi string) (Paper, error)
-	Search(ctx context.Context, title, keyword string, sortBy string, orderDesc bool) ([]Paper, error)
+	Search(ctx context.Context, opts SearchOptions) (SearchResult, error)
 	List(ctx context.Context) ([]Paper, error)
 
 	// commands
 	Save(ctx context.Context, paper Paper) error
 	Update(ctx context.Context, doi string, paper Paper) error
 	Delete(ctx context.Context, doi string) error
+}
+
+type SearchOptions struct {
+	Query    string
+	SortBy   string
+	Desc     bool
+	Page     int
+	PageSize int
+}
+
+type SearchResult struct {
+	Items    []Paper
+	Total    int
+	Page     int
+	PageSize int
+	HasNext  bool
 }

--- a/backend/internal/paper/http/handler.go
+++ b/backend/internal/paper/http/handler.go
@@ -41,6 +41,7 @@ func handleSearchPapers(logger *slog.Logger, service *application.PaperService) 
 		}
 
 		resp := NewPaperResponses(result.Items)
+		setSearchPaginationHeaders(w, result)
 
 		if err := server.Encode(w, r, http.StatusOK, resp); err != nil {
 			logger.Error("encode paper response", "error", err)
@@ -48,6 +49,14 @@ func handleSearchPapers(logger *slog.Logger, service *application.PaperService) 
 			return
 		}
 	})
+}
+
+func setSearchPaginationHeaders(w http.ResponseWriter, result domain.SearchResult) {
+	w.Header().Set("X-Page", strconv.Itoa(result.Page))
+	w.Header().Set("X-Page-Size", strconv.Itoa(result.PageSize))
+	w.Header().Set("X-Total-Count", strconv.Itoa(result.Total))
+	w.Header().Set("X-Has-Next", strconv.FormatBool(result.HasNext))
+	w.Header().Set("Access-Control-Expose-Headers", "X-Page, X-Page-Size, X-Total-Count, X-Has-Next")
 }
 
 func handleGetPaperByUUID(logger *slog.Logger, service *application.PaperService) http.Handler {

--- a/backend/internal/paper/http/handler.go
+++ b/backend/internal/paper/http/handler.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/paperstacks.io/paperstacks/internal/common/server"
@@ -11,46 +12,41 @@ import (
 	"github.com/paperstacks.io/paperstacks/internal/paper/domain"
 )
 
-func handleListPapers(logger *slog.Logger, service *application.PaperService) http.Handler {
-	return http.HandlerFunc(
-		func(w http.ResponseWriter, r *http.Request) {
-			papers, err := service.List(r.Context())
-			if err != nil {
-				if errors.Is(err, domain.ErrPaperNotFound) {
-					logger.Error("read papers", "error", err.Error())
-					http.Error(w, err.Error(), http.StatusNotFound)
-					return
-				}
+func handleSearchPapers(logger *slog.Logger, service *application.PaperService) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := normalizeQueryParam(r.URL.Query().Get("q"))
+		sortByRaw := normalizeQueryParam(r.URL.Query().Get("sortBy"))
+		page, _ := strconv.Atoi(normalizeQueryParam(r.URL.Query().Get("page")))
+		pageSize, _ := strconv.Atoi(normalizeQueryParam(r.URL.Query().Get("pageSize")))
 
-				logger.Error("read papers", "error", err.Error())
-				http.Error(w, err.Error(), http.StatusInternalServerError)
+		sortBy, desc := strings.CutPrefix(sortByRaw, "-")
+		sortBy, _ = strings.CutPrefix(sortBy, "+")
+
+		result, err := service.Search(r.Context(), domain.SearchOptions{
+			Query:    query,
+			SortBy:   sortBy,
+			Desc:     desc,
+			Page:     page,
+			PageSize: pageSize,
+		})
+		if err != nil {
+			if errors.Is(err, domain.ErrInvalidSearch) {
+				http.Error(w, "invalid search options", http.StatusBadRequest)
 				return
 			}
 
-			resp := NewPaperResponses(papers)
-			if err := server.Encode(w, r, http.StatusOK, resp); err != nil {
-				logger.Error("encode paper resp", "error", err)
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
-		},
-	)
-}
-
-func handleListOrSearchPapers(logger *slog.Logger, service *application.PaperService) http.Handler {
-	listHandler := handleListPapers(logger, service)
-	searchHandler := handleSearchPapers(logger, service)
-
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		title := normalizeQueryParam(r.URL.Query().Get("title"))
-		keyword := normalizeQueryParam(r.URL.Query().Get("keyword"))
-		sortBy := normalizeQueryParam(r.URL.Query().Get("sortBy"))
-
-		if title == "" && keyword == "" && sortBy == "" {
-			listHandler.ServeHTTP(w, r)
+			logger.Error("read papers", "error", err.Error())
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
-		searchHandler.ServeHTTP(w, r)
+		resp := NewPaperResponses(result.Items)
+
+		if err := server.Encode(w, r, http.StatusOK, resp); err != nil {
+			logger.Error("encode paper response", "error", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	})
 }
 
@@ -211,37 +207,6 @@ func handleUpdatePaper(logger *slog.Logger, service *application.PaperService) h
 			w.WriteHeader(http.StatusNoContent)
 		},
 	)
-}
-
-func handleSearchPapers(logger *slog.Logger, service *application.PaperService) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		title := normalizeQueryParam(r.URL.Query().Get("title"))
-		keyword := normalizeQueryParam(r.URL.Query().Get("keyword"))
-		sortBy := normalizeQueryParam(r.URL.Query().Get("sortBy"))
-
-		sortBy, desc := strings.CutPrefix(sortBy, "-")
-
-		isAllowedSortKey := sortBy == "title" || sortBy == "year"
-		if sortBy != "" && !isAllowedSortKey {
-			http.Error(w, "invalid 'sortBy': allowed values are 'title', 'year'", http.StatusBadRequest)
-			return
-		}
-
-		papers, err := service.Search(r.Context(), title, keyword, sortBy, desc)
-		if err != nil {
-			logger.Error("read papers", "error", err.Error())
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		resp := NewPaperResponses(papers)
-
-		if err := server.Encode(w, r, http.StatusOK, resp); err != nil {
-			logger.Error("encode paper response", "error", err)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-	})
 }
 
 func normalizeQueryParam(s string) string {

--- a/backend/internal/paper/http/routes.go
+++ b/backend/internal/paper/http/routes.go
@@ -16,7 +16,7 @@ func AddPaperRoute(
 ) {
 	defaultMiddle := middleware.NewDefault(logger)
 
-	mux.Handle(http.MethodGet+" /papers", defaultMiddle(handleListOrSearchPapers(logger, paperService)))
+	mux.Handle(http.MethodGet+" /papers", defaultMiddle(handleSearchPapers(logger, paperService)))
 	mux.Handle(http.MethodGet+" /papers/{uuid}", defaultMiddle(handleGetPaperByUUID(logger, paperService)))
 	mux.Handle(http.MethodGet+" /papers/doi/{doi...}", defaultMiddle(handleGetPaperByDOI(logger, paperService)))
 

--- a/backend/internal/paper/repository/memory/repository.go
+++ b/backend/internal/paper/repository/memory/repository.go
@@ -102,7 +102,6 @@ func (r *Repository) Delete(_ context.Context, doi string) error {
 func (r *Repository) Search(_ context.Context, opts domain.SearchOptions) (domain.SearchResult, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-
 	result := make([]domain.Paper, 0, len(r.data))
 
 	for _, paper := range r.data {

--- a/backend/internal/paper/repository/memory/repository.go
+++ b/backend/internal/paper/repository/memory/repository.go
@@ -99,51 +99,70 @@ func (r *Repository) Delete(_ context.Context, doi string) error {
 	return domain.ErrPaperNotFound
 }
 
-func (r *Repository) Search(_ context.Context, title, keyword string, sortBy string, orderDesc bool) ([]domain.Paper, error) {
+func (r *Repository) Search(_ context.Context, opts domain.SearchOptions) (domain.SearchResult, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	var result []domain.Paper
-
-	if title == "" && keyword == "" {
-		return []domain.Paper{}, nil
-	}
+	result := make([]domain.Paper, 0, len(r.data))
 
 	for _, paper := range r.data {
-
-		matchesTitle := title != "" && strings.Contains(strings.ToLower(paper.Title), title)
-		matchesKeyword := keyword != "" && containsText(paper.Keywords, keyword)
-
-		if matchesTitle || matchesKeyword {
+		if matchesQuery(paper, opts.Query) {
 			result = append(result, paper)
 		}
 	}
 
-	if sortBy != "" {
-		sortPapersByOrder(result, sortBy, orderDesc)
+	if opts.SortBy != "" {
+		sortPapersByOrder(result, opts.SortBy, opts.Desc)
 	}
 
-	return result, nil
+	page := max(1, opts.Page)
+
+	pageSize := len(result)
+	if opts.PageSize > 0 {
+		pageSize = opts.PageSize
+	}
+	pageSize = max(1, pageSize)
+
+	total := len(result)
+	start := min((page-1)*pageSize, total)
+	end := min(start+pageSize, total)
+
+	items := make([]domain.Paper, 0, end-start)
+	items = append(items, result[start:end]...)
+
+	return domain.SearchResult{
+		Items:    items,
+		Total:    total,
+		Page:     page,
+		PageSize: pageSize,
+		HasNext:  end < total,
+	}, nil
 }
 
-func sortPapersByOrder(papers []domain.Paper, sortBy string, desc bool) ([]domain.Paper, error) {
-	if len(papers) == 1 {
-		return papers, nil
-	}
-
+func sortPapersByOrder(papers []domain.Paper, sortBy string, desc bool) {
 	sort.Slice(papers, func(i, j int) bool {
+		if papers[i].DOI == papers[j].DOI {
+			return compare(papers[i].UUID, papers[j].UUID, false)
+		}
+
 		switch sortBy {
 		case "title":
+			if papers[i].Title == papers[j].Title {
+				return compare(papers[i].DOI, papers[j].DOI, false)
+			}
+
 			return compare(papers[i].Title, papers[j].Title, desc)
 		case "year":
+			if papers[i].PublicationYear == papers[j].PublicationYear {
+				return compare(papers[i].DOI, papers[j].DOI, false)
+			}
+
 			return compare(papers[i].PublicationYear, papers[j].PublicationYear, desc)
 
 		default:
-			return false
+			return compare(papers[i].DOI, papers[j].DOI, false)
 		}
 	})
-
-	return papers, nil
 }
 
 func compare[T cmp.Ordered](a, b T, desc bool) bool {
@@ -161,4 +180,16 @@ func containsText(slice []string, text string) bool {
 		}
 	}
 	return false
+}
+
+func matchesQuery(paper domain.Paper, query string) bool {
+	if query == "" {
+		return true
+	}
+
+	if strings.Contains(strings.ToLower(paper.Title), query) {
+		return true
+	}
+
+	return containsText(paper.Keywords, query)
 }

--- a/backend/internal/paper/repository/memory/repository_test.go
+++ b/backend/internal/paper/repository/memory/repository_test.go
@@ -53,15 +53,15 @@ func TestRepositorySearchByTitle(t *testing.T) {
 
 	repo := NewRepository()
 
-	papers, err := repo.Search(context.Background(), "exploratory testing", "", "", false)
+	result, err := repo.Search(context.Background(), domain.SearchOptions{Query: "exploratory testing"})
 	if err != nil {
 		t.Fatalf("Search() error = %v, want nil", err)
 	}
-	if len(papers) != 1 {
-		t.Fatalf("Search() returned %d papers, want 1", len(papers))
+	if len(result.Items) != 1 {
+		t.Fatalf("Search() returned %d papers, want 1", len(result.Items))
 	}
-	if papers[0].DOI != "10.1109/isese.2005.1541817" {
-		t.Fatalf("Search() DOI = %q, want %q", papers[0].DOI, "10.1109/isese.2005.1541817")
+	if result.Items[0].DOI != "10.1109/isese.2005.1541817" {
+		t.Fatalf("Search() DOI = %q, want %q", result.Items[0].DOI, "10.1109/isese.2005.1541817")
 	}
 }
 
@@ -70,56 +70,90 @@ func TestRepositorySearchByKeyword(t *testing.T) {
 
 	repo := NewRepository()
 
-	papers, err := repo.Search(context.Background(), "", "gui testing", "", false)
+	result, err := repo.Search(context.Background(), domain.SearchOptions{Query: "gui testing"})
 	if err != nil {
 		t.Fatalf("Search() error = %v, want nil", err)
 	}
-	if len(papers) != 3 {
-		t.Fatalf("Search() returned %d papers, want 3", len(papers))
+	if len(result.Items) != 3 {
+		t.Fatalf("Search() returned %d papers, want 3", len(result.Items))
 	}
 }
 
-func TestRepositorySearchByTitleAndKeywordSamePaper(t *testing.T) {
+func TestRepositorySearchEmptyQueryReturnsAllPapers(t *testing.T) {
 	t.Parallel()
 
 	repo := NewRepository()
 
-	papers, err := repo.Search(context.Background(), "augmented testing", "bayesian data analysis", "", false)
+	result, err := repo.Search(context.Background(), domain.SearchOptions{})
 	if err != nil {
 		t.Fatalf("Search() error = %v, want nil", err)
 	}
-	if len(papers) != 1 {
-		t.Fatalf("Search() returned %d papers, want 1", len(papers))
+	if result.Total != 4 {
+		t.Fatalf("Search() total = %d, want 4", result.Total)
 	}
-	if papers[0].DOI != "10.1007/s10664-024-10522-z" {
-		t.Fatalf("Search() DOI = %q, want %q", papers[0].DOI, "10.1007/s10664-024-10522-z")
+	if len(result.Items) != 4 {
+		t.Fatalf("Search() items = %d, want 4", len(result.Items))
 	}
 }
 
-func TestRepositorySearchByTitleAndKeywordDifferentPapers(t *testing.T) {
+func TestRepositorySearchSortByYearDescending(t *testing.T) {
 	t.Parallel()
 
 	repo := NewRepository()
 
-	papers, err := repo.Search(context.Background(), "a multiple case study", "bayesian data analysis", "", false)
+	result, err := repo.Search(context.Background(), domain.SearchOptions{SortBy: "year", Desc: true})
 	if err != nil {
 		t.Fatalf("Search() error = %v, want nil", err)
 	}
-	if len(papers) != 2 {
-		t.Fatalf("Search() returned %d papers, want 2", len(papers))
+	if len(result.Items) != 4 {
+		t.Fatalf("Search() returned %d papers, want 4", len(result.Items))
+	}
+	if result.Items[0].DOI != "10.1007/s10664-024-10522-z" {
+		t.Fatalf("Search() first DOI = %q, want %q", result.Items[0].DOI, "10.1007/s10664-024-10522-z")
 	}
 }
 
-func TestRepositorySearchNoResultReturnsNotFound(t *testing.T) {
+func TestRepositorySearchPaginatesResults(t *testing.T) {
 	t.Parallel()
 
 	repo := NewRepository()
 
-	result, err := repo.Search(context.Background(), "nonexistent title", "", "", false)
-	if len(result) != 0 {
-		t.Fatalf("Search() result = %v, want empty slice", len(result))
-	}
+	result, err := repo.Search(context.Background(), domain.SearchOptions{SortBy: "title", Page: 2, PageSize: 2})
 	if err != nil {
 		t.Fatalf("Search() error = %v, want nil", err)
+	}
+
+	if result.Total != 4 {
+		t.Fatalf("Search() total = %d, want 4", result.Total)
+	}
+	if len(result.Items) != 2 {
+		t.Fatalf("Search() items = %d, want 2", len(result.Items))
+	}
+	if result.Page != 2 {
+		t.Fatalf("Search() page = %d, want 2", result.Page)
+	}
+	if result.PageSize != 2 {
+		t.Fatalf("Search() pageSize = %d, want 2", result.PageSize)
+	}
+	if result.HasNext {
+		t.Fatalf("Search() hasNext = true, want false")
+	}
+
+	if result.Items[0].DOI != "10.1109/isese.2005.1541817" {
+		t.Fatalf("Search() first item DOI = %q, want %q", result.Items[0].DOI, "10.1109/isese.2005.1541817")
+	}
+}
+
+func TestRepositorySearchNoResultReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	repo := NewRepository()
+
+	result, err := repo.Search(context.Background(), domain.SearchOptions{Query: "nonexistent title"})
+	if err != nil {
+		t.Fatalf("Search() error = %v, want nil", err)
+	}
+	if len(result.Items) != 0 {
+		t.Fatalf("Search() result = %v, want empty slice", len(result.Items))
 	}
 }

--- a/backend/internal/web/handler.go
+++ b/backend/internal/web/handler.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/paperstacks.io/paperstacks/internal/common/build"
 	"github.com/paperstacks.io/paperstacks/internal/paper/application"
+	"github.com/paperstacks.io/paperstacks/internal/paper/domain"
 )
 
 type pageData struct {
@@ -60,7 +61,11 @@ func handlePapersSearch(
 		sortBy, _ := strings.CutPrefix(sortByRaw, "+")
 		sortBy, desc := strings.CutPrefix(sortBy, "-")
 
-		foundPapers, err := paperService.Search(context.Background(), search, search, sortBy, desc)
+		result, err := paperService.Search(context.Background(), domain.SearchOptions{
+			Query:  search,
+			SortBy: sortBy,
+			Desc:   desc,
+		})
 		if err != nil {
 			logger.Error("read papers", "error", err.Error())
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -68,7 +73,7 @@ func handlePapersSearch(
 		}
 
 		templateName := "papers/partials/papers-list"
-		if err := tmpl.ExecuteTemplate(w, templateName, foundPapers); err != nil {
+		if err := tmpl.ExecuteTemplate(w, templateName, result.Items); err != nil {
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		}
 	})


### PR DESCRIPTION
This PR unifies the title and keyword search into a single query `q`.
It further introduces pagination options with response headers that reflect the pagination status.

New query 

GET /api/papers?q=gui

GET /api/papers?q=gui&page=1&pageSize=10

New header info:

```
HTTP/1.1 200 OK
Access-Control-Expose-Headers: X-Page, X-Page-Size, X-Total-Count, X-Has-Next
Content-Type: application/json
X-Has-Next: false
X-Page: 3
X-Page-Size: 2
X-Total-Count: 4
Date: Tue, 07 Apr 2026 18:47:16 GMT
Content-Length: 3
```