### PR TITLE
Refactor paper delete to use UUID instead of DOI

### DIFF
--- a/backend/internal/paper/application/service.go
+++ b/backend/internal/paper/application/service.go
@@ -63,8 +63,8 @@ func (s *PaperService) Update(ctx context.Context, doi string, paper domain.Pape
 	return s.repo.Update(ctx, doi, paper)
 }
 
-func (s *PaperService) Delete(ctx context.Context, doi string) error {
-	return s.repo.Delete(ctx, strings.TrimSpace(doi))
+func (s *PaperService) Delete(ctx context.Context, uuid string) error {
+	return s.repo.Delete(ctx, strings.TrimSpace(uuid))
 }
 
 func (s *PaperService) Search(ctx context.Context, opts domain.SearchOptions) (domain.SearchResult, error) {

--- a/backend/internal/paper/domain/repository.go
+++ b/backend/internal/paper/domain/repository.go
@@ -23,7 +23,7 @@ type Repository interface {
 	// commands
 	Save(ctx context.Context, paper Paper) error
 	Update(ctx context.Context, doi string, paper Paper) error
-	Delete(ctx context.Context, doi string) error
+	Delete(ctx context.Context, uuid string) error
 }
 
 type SearchOptions struct {

--- a/backend/internal/paper/http/handler.go
+++ b/backend/internal/paper/http/handler.go
@@ -125,21 +125,20 @@ func handleGetPaperByDOI(logger *slog.Logger, service *application.PaperService)
 func handleDeletePaper(logger *slog.Logger, service *application.PaperService) http.Handler {
 	return http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			id := r.PathValue("doi")
+			id := r.PathValue("uuid")
 			if id == "" {
-				http.Error(w, "missing paper id", http.StatusBadRequest)
+				http.Error(w, "missing paper uuid", http.StatusBadRequest)
 				return
 			}
 
 			if err := service.Delete(r.Context(), id); err != nil {
+				logger.Error("delete paper", "uuid", id, "error", err)
 				if errors.Is(err, domain.ErrPaperNotFound) {
-					logger.Error("delete paper", "id", id, "error", err)
-					http.Error(w, "paper not found", http.StatusNotFound)
+					http.Error(w, "paper not found with UUID: "+id, http.StatusNotFound)
 					return
 				}
 
-				logger.Error("delete paper", "id", id, "error", err)
-				http.Error(w, "internal server error", http.StatusInternalServerError)
+				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
 

--- a/backend/internal/paper/http/routes.go
+++ b/backend/internal/paper/http/routes.go
@@ -20,7 +20,7 @@ func AddPaperRoute(
 	mux.Handle(http.MethodGet+" /papers/{uuid}", defaultMiddle(handleGetPaperByUUID(logger, paperService)))
 	mux.Handle(http.MethodGet+" /papers/doi/{doi...}", defaultMiddle(handleGetPaperByDOI(logger, paperService)))
 
-	mux.Handle(http.MethodDelete+" /papers/doi/{doi...}", defaultMiddle(handleDeletePaper(logger, paperService)))
+	mux.Handle(http.MethodDelete+" /papers/{uuid}", defaultMiddle(handleDeletePaper(logger, paperService)))
 	mux.Handle(http.MethodPost+" /papers", defaultMiddle(handleSavePaper(logger, paperService)))
 	mux.Handle(http.MethodPut+" /papers/doi/{doi...}", defaultMiddle(handleUpdatePaper(logger, paperService)))
 }

--- a/backend/internal/paper/repository/memory/repository.go
+++ b/backend/internal/paper/repository/memory/repository.go
@@ -85,12 +85,12 @@ func (r *Repository) Update(_ context.Context, doi string, paper domain.Paper) e
 	return domain.ErrPaperNotFound
 }
 
-func (r *Repository) Delete(_ context.Context, doi string) error {
+func (r *Repository) Delete(_ context.Context, uuid string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	for i, item := range r.data {
-		if item.DOI == doi {
+		if item.UUID == uuid {
 			r.data = append(r.data[:i], r.data[i+1:]...)
 			return nil
 		}


### PR DESCRIPTION
This PR refactors the `DELETE /papers/{doi}` API endpoint with `DELETE /papers/{uuid}` and the underlying repository code.