### PR TITLE
Refactor integration test run

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -21,7 +21,7 @@ test: ## Run all unit tests
 
 .PHONY: test-integration
 test-integration: ## Run all integration tests
-	INTEGRATION=1 $(GOCMD) test -run '^TestIntegration' ./... -coverprofile=coverage.out
+	INTEGRATION=1 $(GOCMD) test -parallel=1 -run '^TestIntegration' ./... -coverprofile=coverage.out
 
 .PHONY: build
 build: build-server ## Build all

--- a/backend/internal/integration/helpers.go
+++ b/backend/internal/integration/helpers.go
@@ -7,7 +7,23 @@ import (
 	"io"
 	"net/http"
 	"testing"
+
+	"github.com/paperstacks.io/paperstacks/internal/paper/repository/memory"
 )
+
+func setupIntegrationTest(t *testing.T) {
+	t.Helper()
+
+	integrationTestMu.Lock()
+
+	if testRepo == nil {
+		integrationTestMu.Unlock()
+		t.Fatal("integration test repository is not initialized")
+	}
+
+	testRepo = memory.NewRepository()
+	t.Cleanup(integrationTestMu.Unlock)
+}
 
 // doRequest makes an HTTP request and returns the response.
 // The caller is responsible for closing resp.Body.

--- a/backend/internal/integration/main_integration_test.go
+++ b/backend/internal/integration/main_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -27,6 +28,8 @@ const (
 )
 
 var client *http.Client
+var testRepo *memory.Repository
+var integrationTestMu sync.Mutex
 
 func startApplication() bool {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
@@ -34,7 +37,8 @@ func startApplication() bool {
 	api := http.NewServeMux()
 	server.AddRoute(root, context.Background(), logger)
 
-	paperService := application.NewPaperService(memory.NewRepository())
+	testRepo = memory.NewRepository()
+	paperService := application.NewPaperService(testRepo)
 	paperHttp.AddPaperRoute(api, logger, paperService)
 	root.Handle("/api/", http.StripPrefix("/api", api))
 

--- a/backend/internal/integration/paper_integration_test.go
+++ b/backend/internal/integration/paper_integration_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestIntegrationSearchPapersQueryParams(t *testing.T) {
-	t.Parallel()
+	setupIntegrationTest(t)
 
 	type testCase struct {
 		query             string
@@ -48,8 +48,6 @@ func TestIntegrationSearchPapersQueryParams(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.query+"_"+tc.sortBy, func(t *testing.T) {
-			t.Parallel()
-
 			u, err := url.Parse(testAPIPath + "/api/papers")
 			if err != nil {
 				t.Fatalf("failed to parse url: %v", err)
@@ -102,7 +100,7 @@ func TestIntegrationSearchPapersQueryParams(t *testing.T) {
 }
 
 func TestIntegrationSearchPapersPaginationHeaders(t *testing.T) {
-	t.Parallel()
+	setupIntegrationTest(t)
 
 	type testCase struct {
 		name             string
@@ -149,8 +147,6 @@ func TestIntegrationSearchPapersPaginationHeaders(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
 			u, err := url.Parse(testAPIPath + "/api/papers")
 			if err != nil {
 				t.Fatalf("failed to parse url: %v", err)
@@ -200,6 +196,8 @@ func TestIntegrationSearchPapersPaginationHeaders(t *testing.T) {
 }
 
 func TestIntegrationListPapers(t *testing.T) {
+	setupIntegrationTest(t)
+
 	endpoint := testAPIPath + "/api/papers"
 	resp := doGetRequest(t, endpoint)
 	defer resp.Body.Close()
@@ -215,6 +213,8 @@ func TestIntegrationListPapers(t *testing.T) {
 }
 
 func TestIntegrationGetPaperByUUID(t *testing.T) {
+	setupIntegrationTest(t)
+
 	uuid := "a4b065f1-1b88-4f50-a7fe-1177f3489fcf"
 	endpoint := testAPIPath + "/api/papers/" + uuid
 	resp := doGetRequest(t, endpoint)
@@ -228,4 +228,16 @@ func TestIntegrationGetPaperByUUID(t *testing.T) {
 	if paper.UUID != uuid {
 		t.Fatalf("expected paper to have UUID %s, got %s", uuid, paper.UUID)
 	}
+}
+
+func TestIntegrationDeletePaper(t *testing.T) {
+	setupIntegrationTest(t)
+
+	uuid := "a4b065f1-1b88-4f50-a7fe-1177f3489fcf"
+	endpoint := testAPIPath + "/api/papers/" + uuid
+	resp := doDeleteRequest(t, endpoint)
+	assertStatusCode(t, resp, http.StatusNoContent)
+
+	resp = doGetRequest(t, endpoint)
+	assertStatusCode(t, resp, http.StatusNotFound)
 }


### PR DESCRIPTION
This PR refactors the way integration tests are run.

The func `setupIntegrationTest` ensures only one tests runs at a time and prepares a fixed state for the test.