### PR TITLE
Refactor create paper response in HTTP API

### DIFF
--- a/backend/internal/common/server/location.go
+++ b/backend/internal/common/server/location.go
@@ -1,0 +1,23 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func Location(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	if forwardedProto := r.Header.Get("X-Forwarded-Proto"); forwardedProto != "" {
+		scheme = forwardedProto
+	}
+
+	host := r.Host
+	if forwardedHost := r.Header.Get("X-Forwarded-Host"); forwardedHost != "" {
+		host = forwardedHost
+	}
+
+	return fmt.Sprintf("%s://%s", scheme, host)
+}

--- a/backend/internal/integration/paper_integration_test.go
+++ b/backend/internal/integration/paper_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/paperstacks.io/paperstacks/internal/paper/domain"
 	paperHttp "github.com/paperstacks.io/paperstacks/internal/paper/http"
 )
 
@@ -240,4 +241,28 @@ func TestIntegrationDeletePaper(t *testing.T) {
 
 	resp = doGetRequest(t, endpoint)
 	assertStatusCode(t, resp, http.StatusNotFound)
+}
+
+func TestIntegrationSavePaper(t *testing.T) {
+	setupIntegrationTest(t)
+
+	paper := domain.Paper{
+		DOI:   "10.1109/some_DOI",
+		Title: "Test article",
+	}
+	endpoint := testAPIPath + "/api/papers"
+	resp := doPostRequest(t, endpoint, paper)
+	defer resp.Body.Close()
+	assertStatusCode(t, resp, http.StatusCreated)
+
+	loc := resp.Header.Get("location")
+	if loc == "" {
+		t.Fatal("expected location header to be not empty")
+	}
+
+	var created paperHttp.PaperResponse
+	decodeJSON(t, resp, &created)
+	if created.UUID == "" {
+		t.Fatal("expected UUID to be not empty")
+	}
 }

--- a/backend/internal/paper/application/service.go
+++ b/backend/internal/paper/application/service.go
@@ -34,11 +34,11 @@ func (s *PaperService) GetByDOI(ctx context.Context, doi string) (domain.Paper, 
 	return s.repo.GetByDOI(ctx, strings.TrimSpace(doi))
 }
 
-func (s *PaperService) Create(ctx context.Context, paper domain.Paper) error {
+func (s *PaperService) Create(ctx context.Context, paper domain.Paper) (domain.Paper, error) {
 	paper.UUID = uuid.NewString()
 	paper = paper.Normalize()
 	if err := paper.Validate(); err != nil {
-		return err
+		return domain.Paper{}, err
 	}
 
 	return s.repo.Save(ctx, paper)

--- a/backend/internal/paper/application/service_test.go
+++ b/backend/internal/paper/application/service_test.go
@@ -14,7 +14,7 @@ func TestServiceCreateNormalizesAndValidatesPaper(t *testing.T) {
 
 	service := NewPaperService(memory.NewRepository())
 
-	err := service.Create(context.Background(), domain.Paper{
+	_, err := service.Create(context.Background(), domain.Paper{
 		DOI:   " 10.1000/example ",
 		Title: " Example Paper ",
 	})

--- a/backend/internal/paper/domain/repository.go
+++ b/backend/internal/paper/domain/repository.go
@@ -21,7 +21,7 @@ type Repository interface {
 	List(ctx context.Context) ([]Paper, error)
 
 	// commands
-	Save(ctx context.Context, paper Paper) error
+	Save(ctx context.Context, paper Paper) (Paper, error)
 	Update(ctx context.Context, uuid string, paper Paper) error
 	Delete(ctx context.Context, uuid string) error
 }

--- a/backend/internal/paper/http/handler.go
+++ b/backend/internal/paper/http/handler.go
@@ -157,7 +157,8 @@ func handleSavePaper(logger *slog.Logger, service *application.PaperService) htt
 			}
 
 			p := req.toDomain()
-			if err := service.Create(r.Context(), p); err != nil {
+			created, err := service.Create(r.Context(), p)
+			if err != nil {
 				if errors.Is(err, domain.ErrPaperAlreadyExists) {
 					logger.Error("create paper", "doi", p.DOI, "error", err)
 					http.Error(w, err.Error(), http.StatusConflict)
@@ -174,7 +175,15 @@ func handleSavePaper(logger *slog.Logger, service *application.PaperService) htt
 				return
 			}
 
-			w.WriteHeader(http.StatusCreated)
+			resp := NewPaperResponse(created)
+
+			loc := server.Location(r) + "/" + created.UUID
+			w.Header().Set("location", loc)
+
+			if err := server.Encode(w, r, http.StatusCreated, resp); err != nil {
+				logger.Error("encode paper resp", "error", err)
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
 		},
 	)
 }

--- a/backend/internal/paper/repository/memory/repository.go
+++ b/backend/internal/paper/repository/memory/repository.go
@@ -57,18 +57,18 @@ func (r *Repository) List(_ context.Context) ([]domain.Paper, error) {
 	return out, nil
 }
 
-func (r *Repository) Save(_ context.Context, paper domain.Paper) error {
+func (r *Repository) Save(_ context.Context, paper domain.Paper) (domain.Paper, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	for _, item := range r.data {
-		if item.DOI == paper.DOI {
-			return domain.ErrPaperAlreadyExists
+		if item.UUID == paper.UUID {
+			return domain.Paper{}, domain.ErrPaperAlreadyExists
 		}
 	}
 
 	r.data = append(r.data, paper)
-	return nil
+	return paper, nil
 }
 
 func (r *Repository) Update(_ context.Context, uuid string, paper domain.Paper) error {

--- a/backend/internal/paper/repository/memory/repository_test.go
+++ b/backend/internal/paper/repository/memory/repository_test.go
@@ -39,8 +39,8 @@ func TestRepositorySaveReturnsAlreadyExists(t *testing.T) {
 
 	repo := NewRepository()
 
-	err := repo.Save(context.Background(), domain.Paper{
-		DOI:   "10.1109/isese.2005.1541817",
+	_, err := repo.Save(context.Background(), domain.Paper{
+		UUID:  "6752de78-0264-4ac5-8bd3-4eed7d3f5484",
 		Title: "duplicate",
 	})
 	if err != domain.ErrPaperAlreadyExists {

--- a/backend/internal/server/handle_root.go
+++ b/backend/internal/server/handle_root.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/paperstacks.io/paperstacks/internal/common/server"
@@ -18,20 +17,7 @@ func handleRoot() http.Handler {
 	}
 	return http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			scheme := "http"
-			if r.TLS != nil {
-				scheme = "https"
-			}
-			if forwardedProto := r.Header.Get("X-Forwarded-Proto"); forwardedProto != "" {
-				scheme = forwardedProto
-			}
-
-			host := r.Host
-			if forwardedHost := r.Header.Get("X-Forwarded-Host"); forwardedHost != "" {
-				host = forwardedHost
-			}
-
-			baseURL := fmt.Sprintf("%s://%s", scheme, host)
+			baseURL := server.Location(r)
 
 			resp := RootResponse{
 				Message: "Welcome to paperstacks.io",


### PR DESCRIPTION
This PR refactors the response when creating a new paper via the HTTP API.
As the UUID is created by the paper service it was not possible to know which UUID the created paper got assigned, and thus, how to access the created paper directly. 


- Response header contains now the [location](https://en.wikipedia.org/wiki/HTTP_location) of the created paper.
- Response return the create paper to be able to know its UUID or other properties