### PR TITLE
Add minimal domain model for User

### DIFF
--- a/backend/internal/auth/domain/user.go
+++ b/backend/internal/auth/domain/user.go
@@ -1,0 +1,8 @@
+// Package domain defines the core domain models used authentication and authorization.
+package domain
+
+// User represents an authenticated person in the system.
+type User struct {
+	// Email is the user's email address as provided by the authentication system.
+	Email string
+}


### PR DESCRIPTION
This PR is the first step towards implementing the domain model for `User`.
As not authentication provider is chosen yet, it provides a minimal interface to be already used by other domains, e.g., stacks. 

This PR contributes to Issue #96 but doesn't close it.