### PR TITLE
Add config from env files

### DIFF
--- a/backend/.air.toml
+++ b/backend/.air.toml
@@ -1,6 +1,6 @@
 #:schema https://json.schemastore.org/any.json
 
-env_files = []
+env_files = [".env"]
 root = "."
 testdata_dir = "testdata"
 tmp_dir = "tmp"

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -6,3 +6,6 @@ node_modules/
 
 /server
 /server.exe
+
+# Envs
+.env*

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -126,9 +126,9 @@ func banner(w io.Writer) {
 func main() {
 	banner(os.Stdout)
 
-	conf := config.New()
+	cfg := config.New()
 
-	if err := run(context.Background(), conf); err != nil {
+	if err := run(context.Background(), cfg); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -14,7 +14,9 @@ import (
 	"text/tabwriter"
 	"time"
 
+	_ "github.com/joho/godotenv/autoload"
 	"github.com/paperstacks.io/paperstacks/internal/common/build"
+	"github.com/paperstacks.io/paperstacks/internal/common/config"
 	doiApp "github.com/paperstacks.io/paperstacks/internal/doi/application"
 	doiHttp "github.com/paperstacks.io/paperstacks/internal/doi/http"
 	paperApp "github.com/paperstacks.io/paperstacks/internal/paper/application"
@@ -26,16 +28,10 @@ import (
 
 func run(
 	ctx context.Context,
-	getenv func(string) string,
+	cfg config.Config,
 ) error {
-	host := getenv("HOST")
-	if host == "" {
-		host = "127.0.0.1"
-	}
-	port := getenv("PORT")
-	if port == "" {
-		port = "8080"
-	}
+	host := cfg.Host
+	port := cfg.Port
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	paperService := paperApp.NewPaperService(memory.NewRepository())
@@ -54,6 +50,7 @@ func run(
 		logger,
 		paperService,
 	)
+
 	doiHttp.AddDOIRoute(apiMux, logger, doiService)
 	web.AddRoute(webMux, logger, paperService)
 	rootMux.Handle("/api/", http.StripPrefix("/api", apiMux))
@@ -129,7 +126,9 @@ func banner(w io.Writer) {
 func main() {
 	banner(os.Stdout)
 
-	if err := run(context.Background(), os.Getenv); err != nil {
+	conf := config.New()
+
+	if err := run(context.Background(), conf); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -2,4 +2,7 @@ module github.com/paperstacks.io/paperstacks
 
 go 1.26
 
-require github.com/google/uuid v1.6.0 // indirect
+require (
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
+)

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,2 +1,4 @@
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=

--- a/backend/internal/common/config/config.go
+++ b/backend/internal/common/config/config.go
@@ -1,0 +1,27 @@
+// Package config provides application-wide startup configuration loaded from
+// environment variables.
+package config
+
+import "os"
+
+// Config contains application startup configuration.
+type Config struct {
+	Host string
+	Port string
+}
+
+// New loads configuration from environment variables and applies defaults.
+func New() Config {
+	return Config{
+		Host: getEnv("HOST", "127.0.0.1"),
+		Port: getEnv("PORT", "8080"),
+	}
+}
+
+func getEnv(key string, defaultVal string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+
+	return defaultVal
+}


### PR DESCRIPTION
This PR introduces the ability to load configs from a `.env` file.
After the `.env` is loaded a configuration structure `config.Config` can be passed into the packages where it is needed.

The rational for this PR is that for issue #7 we need to have the API URL as secret env.
Without this config package other domain specific packages such as `internal/web` need to execute `os.Gentenv()`.
In the future we can also fail the startup if expected env vars are not provided.