### PR TITLE
Add CDN import for CSS

### DIFF
--- a/backend/internal/web/templates/base.html
+++ b/backend/internal/web/templates/base.html
@@ -5,7 +5,13 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{{.Title}} · Paperstacks</title>
-    <link rel="stylesheet" href="/app/assets/styles.css" />
+    <!-- CSS for production -->
+    <!-- <link rel="stylesheet" href="/app/assets/styles.css" /> -->
+    <!-- CSS for development -->
+    <link href="https://cdn.jsdelivr.net/npm/daisyui@5" rel="stylesheet" type="text/css" />
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <link href="https://cdn.jsdelivr.net/npm/daisyui@5/themes.css" rel="stylesheet" type="text/css" />
+
     <script src="/app/assets/htmx.min.js" defer></script>
     <script type="module">
       import { register } from "https://esm.run/@teamhanko/hanko-elements"


### PR DESCRIPTION
This PR changes the import of the CSS file to improve the development experience.

The current `app/assets/style.css` is a minimized CSS file that only contains the styles that are used. During the development of the UI you have to update the CSS when a new CSS class is used. While this behavior creates a minimal CSS it also results in many changes/commits of the `styles.css` file.

To improve the development experience, I import the CSS files for Tailwind and DaisyUI directly via CDN. 
When the UI is more stable and we create proper production builds we can switch back to the previous, optimized, workflow.