### PR TITLE
Extend User model with Paper

### DIFF
--- a/backend/internal/user/application/service_test.go
+++ b/backend/internal/user/application/service_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 	"time"
 
@@ -61,7 +62,7 @@ func TestUserServiceCreateIfNotExistReturnsExistingUser(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateIfNotExist() error = %v, want nil", err)
 	}
-	if res != existing {
+	if !reflect.DeepEqual(res, existing) {
 		t.Fatalf("CreateIfNotExist() = %#v, want existing %#v", res, existing)
 	}
 }
@@ -79,7 +80,7 @@ func TestUserServiceGetByExternalIDTrimsInput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetByExternalID() error = %v, want nil", err)
 	}
-	if user != created {
+	if !reflect.DeepEqual(user, created) {
 		t.Fatalf("GetByExternalID() = %#v, want %#v", user, created)
 	}
 }
@@ -97,7 +98,7 @@ func TestUserServiceGetByEmailNormalizesInput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetByEmail() error = %v, want nil", err)
 	}
-	if user != created {
+	if !reflect.DeepEqual(user, created) {
 		t.Fatalf("GetByEmail() = %#v, want %#v", user, created)
 	}
 }
@@ -228,7 +229,7 @@ func TestUserServiceGetByAuthTokenFetchesAndPersistsUser(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetByExternalID() error = %v, want nil", err)
 	}
-	if stored != user {
+	if !reflect.DeepEqual(stored, user) {
 		t.Fatalf("stored user = %#v, want %#v", stored, user)
 	}
 }

--- a/backend/internal/user/domain/user.go
+++ b/backend/internal/user/domain/user.go
@@ -5,6 +5,8 @@ import (
 	"net/mail"
 	"strings"
 	"time"
+
+	paperDomain "github.com/paperstacks.io/paperstacks/internal/paper/domain"
 )
 
 // User represents an authenticated person in the system.
@@ -14,6 +16,9 @@ type User struct {
 
 	// Email is the user's email address as provided by the authentication system.
 	Email string
+
+	// Papers contains all papers owned by the user.
+	Papers []paperDomain.Paper
 
 	// CreatedAt records when the user was initially created.
 	CreatedAt time.Time
@@ -27,6 +32,7 @@ func NewUser(externalID, email string) User {
 	return User{
 		ExternalID: strings.TrimSpace(externalID),
 		Email:      strings.ToLower(strings.TrimSpace(email)),
+		Papers:     []paperDomain.Paper{},
 		CreatedAt:  now,
 		UpdatedAt:  now,
 	}

--- a/backend/internal/user/repository/memory/repository_test.go
+++ b/backend/internal/user/repository/memory/repository_test.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"context"
+	"reflect"
 	"testing"
 	"time"
 
@@ -18,7 +19,7 @@ func TestRepositorySaveIfNotExistCreatesUser(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SaveIfNotExist() error = %v, want nil", err)
 	}
-	if res != user {
+	if res.ExternalID != user.ExternalID {
 		t.Fatalf("SaveIfNotExist() = %#v, want %#v", res, user)
 	}
 }
@@ -38,7 +39,7 @@ func TestRepositorySaveIfNotExistReturnsExistingUser(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SaveIfNotExist() error = %v, want nil", err)
 	}
-	if res != existing {
+	if !reflect.DeepEqual(res, existing) {
 		t.Fatalf("SaveIfNotExist() = %#v, want existing %#v", res, existing)
 	}
 }
@@ -56,7 +57,7 @@ func TestRepositoryGetByExternalID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetByExternalID() error = %v, want nil", err)
 	}
-	if res != user {
+	if !reflect.DeepEqual(res, user) {
 		t.Fatalf("GetByExternalID() = %#v, want %#v", res, user)
 	}
 }
@@ -85,7 +86,7 @@ func TestRepositoryGetByEmail(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetByEmail() error = %v, want nil", err)
 	}
-	if res != user {
+	if !reflect.DeepEqual(res, user) {
 		t.Fatalf("GetByEmail() = %#v, want %#v", res, user)
 	}
 }
@@ -123,7 +124,7 @@ func TestRepositoryListReturnsAllUsers(t *testing.T) {
 		t.Fatalf("List() returned %d users, want %d", len(res), len(users))
 	}
 	for i, user := range users {
-		if res[i] != user {
+		if !reflect.DeepEqual(res[i], user) {
 			t.Fatalf("List()[%d] = %#v, want %#v", i, res[i], user)
 		}
 	}
@@ -172,7 +173,7 @@ func TestRepositoryUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetByExternalID() error = %v, want nil", err)
 	}
-	if stored != updated {
+	if !reflect.DeepEqual(stored, updated) {
 		t.Fatalf("stored user = %#v, want %#v", stored, updated)
 	}
 }


### PR DESCRIPTION
This PR extends the `User` model with an attribute for `Papers` that it owns.

Contributes to Issue #97 