### PR TITLE
Fix stack sorting persistence during pagination

### DIFF
--- a/backend/internal/web/templates/pages/stacks/partials/stacks-list.html
+++ b/backend/internal/web/templates/pages/stacks/partials/stacks-list.html
@@ -45,6 +45,7 @@
 </ul>
 <form class="mt-6">
   <input type="hidden" name="search" value="{{ .SearchOptions.Query }}" />
+  <input type="hidden" name="sortBy" value="{{ if .SearchOptions.Desc }}-{{ end }}{{ .SearchOptions.SortBy }}" />
   <div class="flex join justify-center">
     <button
       class="join-item btn  {{ if lt .Page 2 }} btn-disabled {{end}}"


### PR DESCRIPTION
When changing pages in the stack list, the selected sort option should be preserved.
This ensures that users can paginate through stack results without losing theri current sorting