### PR TITLE
Extend gitignore to ignore tmp/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 secrets/
 **/.idea/
 **/.vscode/
+
+# Build artifacts
+tmp/


### PR DESCRIPTION
This PR also adds the `tmp/` folder in project root to `gitignore`.

If `air` is executed in the root folder (instead of `backend/`) it will create a `tmp/` folder for build artifacts and logs.