### PR TITLE
Extend CI workflow for docker push

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -65,6 +65,7 @@ jobs:
         run: npm run fmt:check
 
   docker:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [build, format-frontend]
     runs-on: ubuntu-24.04-arm
     permissions:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -73,6 +73,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          fetch-depth: 0
           fetch-tags: true
 
       - name: Compute Docker build args

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -63,3 +63,63 @@ jobs:
 
       - name: Format
         run: npm run fmt:check
+
+  docker:
+    needs: [build, format-frontend]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Compute Docker build args
+        id: build-args
+        working-directory: ./backend
+        run: |
+          GO_VERSION="$(awk '/^go / { print $2 }' go.mod)"
+          APP_VERSION="$(git describe --tags --abbrev=0 02>/dev/null || echo development)"
+          APP_GIT_HASH="$(git rev-parse --short HEAD)"
+          APP_BUILD_TIME="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+          test -n "$GO_VERSION"
+          test -n "$APP_VERSION"
+          test -n "$APP_GIT_HASH"
+          test -n "$APP_BUILD_TIME"
+
+          {
+            echo "go-version=$GO_VERSION"
+            echo "app-version=$APP_VERSION"
+            echo "app-git-hash=$APP_GIT_HASH"
+            echo "app-build-time=$APP_BUILD_TIME"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/paperstacks-io/paperstacks:latest
+            ghcr.io/paperstacks-io/paperstacks:${{ steps.build-args.outputs.app-version }}
+          build-args: |
+            GO_VERSION=${{ steps.build-args.outputs.go-version }}
+            APP_VERSION=${{ steps.build-args.outputs.app-version }}
+            APP_GIT_HASH=${{ steps.build-args.outputs.app-git-hash }}
+            APP_BUILD_TIME=${{ steps.build-args.outputs.app-build-time }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/paperstacks-io/paperstacks
+            org.opencontainers.image.description=paperstacks-io
+            org.opencontainers.image.licenses=MIT

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -72,6 +72,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-tags: true
 
       - name: Compute Docker build args
         id: build-args

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -66,7 +66,7 @@ jobs:
 
   docker:
     needs: [build, format-frontend]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write
@@ -97,7 +97,6 @@ jobs:
             echo "app-build-time=$APP_BUILD_TIME"
           } >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
 
@@ -112,7 +111,7 @@ jobs:
         with:
           context: ./backend
           file: ./backend/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           push: true
           tags: |
             ghcr.io/paperstacks-io/paperstacks:latest

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -79,24 +79,7 @@ jobs:
       - name: Compute Docker build args
         id: build-args
         working-directory: ./backend
-        run: |
-          GO_VERSION="$(awk '/^go / { print $2 }' go.mod)"
-          APP_VERSION="$(git describe --tags --abbrev=0 02>/dev/null || echo development)"
-          APP_GIT_HASH="$(git rev-parse --short HEAD)"
-          APP_BUILD_TIME="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-
-          test -n "$GO_VERSION"
-          test -n "$APP_VERSION"
-          test -n "$APP_GIT_HASH"
-          test -n "$APP_BUILD_TIME"
-
-          {
-            echo "go-version=$GO_VERSION"
-            echo "app-version=$APP_VERSION"
-            echo "app-git-hash=$APP_GIT_HASH"
-            echo "app-build-time=$APP_BUILD_TIME"
-          } >> "$GITHUB_OUTPUT"
-
+        run: make build-github-output >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-buildx-action@v3
 
@@ -120,7 +103,6 @@ jobs:
             GO_VERSION=${{ steps.build-args.outputs.go-version }}
             APP_VERSION=${{ steps.build-args.outputs.app-version }}
             APP_GIT_HASH=${{ steps.build-args.outputs.app-git-hash }}
-            APP_BUILD_TIME=${{ steps.build-args.outputs.app-build-time }}
           labels: |
             org.opencontainers.image.source=https://github.com/paperstacks-io/paperstacks
             org.opencontainers.image.description=paperstacks-io

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -15,7 +15,7 @@ jobs:
         working-directory: ./backend
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -51,7 +51,7 @@ jobs:
       run:
         working-directory: ./backend
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
           node-version: lts/*
@@ -72,7 +72,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -82,9 +82,9 @@ jobs:
         working-directory: ./backend
         run: make build-github-output >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,10 +1,9 @@
 # Build stage
-ARG GO_VERSION=tip
+ARG GO_VERSION
 FROM golang:${GO_VERSION}-alpine AS build
 
 ARG APP_VERSION
 ARG APP_GIT_HASH
-ARG APP_BUILD_TIME
 
 RUN apk add --no-cache make
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,7 +1,8 @@
 GOCMD=go
 BINARY_DIR=.
 BUILD_PKG=github.com/paperstacks.io/paperstacks/internal/common/build
-VERSION ?= $(if $(APP_VERSION),$(APP_VERSION),$(shell git describe --tags 2>/dev/null || echo development))
+GO_VERSION ?= $(shell awk '/^go / { print $$2 }' go.mod)
+VERSION ?= $(if $(APP_VERSION),$(APP_VERSION),$(shell git describe --tags --abbrev=0 2>/dev/null || echo development))
 GIT_HASH ?= $(if $(APP_GIT_HASH),$(APP_GIT_HASH),$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown))
 BUILD_LDFLAGS=-ldflags "-X $(BUILD_PKG).Version=$(VERSION) -X $(BUILD_PKG).GitHash=$(GIT_HASH)"
 
@@ -32,18 +33,26 @@ build-server: ## Build server application
 
 .PHONY: build-docker
 build-docker: ## Build Docker image for server
-	@GO_VERSION=$$(grep '^go ' go.mod | cut -d' ' -f2) && \
-	COMPOSE_CMD=$$(if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then \
+	@COMPOSE_CMD=$$(if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then \
 		printf 'docker compose'; \
 	elif command -v podman >/dev/null 2>&1 && podman compose version >/dev/null 2>&1; then \
 		printf 'podman compose'; \
 	fi) && \
 	test -n "$$COMPOSE_CMD" || { echo "Neither docker compose nor podman compose is installed"; exit 1; } && \
-	echo "Using $$COMPOSE_CMD with Go version $$GO_VERSION from go.mod" && \
-	GO_VERSION=$$GO_VERSION \
+	echo "Using $$COMPOSE_CMD with Go version $(GO_VERSION) from go.mod" && \
+	GO_VERSION=$(GO_VERSION) \
 	APP_VERSION=$(VERSION) \
 	APP_GIT_HASH=$(GIT_HASH) \
-	docker compose build paperstacks
+	$$COMPOSE_CMD build paperstacks
+
+.PHONY: build-github-output
+build-github-output: ## Print build values as GitHub Actions outputs
+	@test -n '$(GO_VERSION)' || { printf '%s\n' 'GO_VERSION is empty' >&2; exit 1; }
+	@test -n '$(VERSION)' || { printf '%s\n' 'VERSION is empty' >&2; exit 1; }
+	@test -n '$(GIT_HASH)' || { printf '%s\n' 'GIT_HASH is empty' >&2; exit 1; }
+	@printf 'go-version=%s\n' '$(GO_VERSION)'
+	@printf 'app-version=%s\n' '$(VERSION)'
+	@printf 'app-git-hash=%s\n' '$(GIT_HASH)'
 
 .PHONY: help
 help:

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -34,19 +34,19 @@ build-server: ## Build server application
 .PHONY: build-docker
 build-docker: ## Build Docker image for server
 	@GO_VERSION=$$(grep '^go ' go.mod | cut -d' ' -f2) && \
-	CONTAINER_CMD=$$(if command -v docker >/dev/null 2>&1; then \
-		printf 'docker'; \
-	elif command -v podman >/dev/null 2>&1; then \
-		printf 'podman'; \
+	COMPOSE_CMD=$$(if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then \
+		printf 'docker compose'; \
+	elif command -v podman >/dev/null 2>&1 && podman compose version >/dev/null 2>&1; then \
+		printf 'podman compose'; \
 	fi) && \
-	test -n "$$CONTAINER_CMD" || { echo "Neither docker nor podman is installed"; exit 1; } && \
-	echo "Using $$CONTAINER_CMD with Go version $$GO_VERSION from go.mod" && \
-	$$CONTAINER_CMD build \
-		--build-arg GO_VERSION=$$GO_VERSION \
-		--build-arg APP_VERSION=$(VERSION) \
-		--build-arg APP_GIT_HASH=$(GIT_HASH) \
-		--build-arg APP_BUILD_TIME=$(BUILD_TIME) \
-		-t paperstacks .
+	test -n "$$COMPOSE_CMD" || { echo "Neither docker compose nor podman compose is installed"; exit 1; } && \
+	echo "Using $$COMPOSE_CMD with Go version $$GO_VERSION from go.mod" && \
+	GO_VERSION=$$GO_VERSION \
+	APP_VERSION=$(VERSION) \
+	APP_GIT_HASH=$(GIT_HASH) \
+	APP_BUILD_TIME=$(BUILD_TIME) \
+	docker compose build paperstacks
+	# $$COMPOSE_CMD build paperstacks
 
 .PHONY: help
 help:

--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -1,8 +1,16 @@
-version: "3.8"
-
 services:
   paperstacks:
-    build: .
-    image: paperstacks
+    build:
+      context: .
+      args:
+        GO_VERSION: ${GO_VERSION:-1}
+        APP_VERSION: ${APP_VERSION:-development}
+        APP_GIT_HASH: ${APP_GIT_HASH:-unknown}
+        APP_BUILD_TIME: ${APP_BUILD_TIME:-}
+      labels:
+        org.opencontainers.image.source: https://github.com/paperstacks-io/paperstacks
+        org.opencontainers.image.description: paperstacks-io
+        org.opencontainers.image.licenses: MIT
+    image: ghcr.io/paperstacks-io/paperstacks:latest
     ports:
       - "8080:8080"

--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -5,7 +5,7 @@ services:
       args:
         GO_VERSION: ${GO_VERSION:-1}
         APP_VERSION: ${APP_VERSION:-development}
-        APP_GIT_HASH: ${APP_GIT_HASH:-unknown}
+        APP_GIT_HASH: ${APP_GIT_HASH}
       labels:
         org.opencontainers.image.source: https://github.com/paperstacks-io/paperstacks
         org.opencontainers.image.description: paperstacks-io


### PR DESCRIPTION
This PR introduces a CI job to build a Docker image for the backend.
This is needed as container management systems like Arcane or Komodo expect a Docker image instead of building it themselves.

Create Docker images will have a tag that represents the latest git tag, like `v0.1.0`, and a `latest` tag.

To ensure a consistent behavior between CI and local builds the `Makefile` and `compose.yaml` files were adjusted