### PR TITLE
Remove build time from build args

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -3,8 +3,7 @@ BINARY_DIR=.
 BUILD_PKG=github.com/paperstacks.io/paperstacks/internal/common/build
 VERSION ?= $(if $(APP_VERSION),$(APP_VERSION),$(shell git describe --tags 2>/dev/null || echo development))
 GIT_HASH ?= $(if $(APP_GIT_HASH),$(APP_GIT_HASH),$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown))
-BUILD_TIME ?= $(if $(APP_BUILD_TIME),$(APP_BUILD_TIME),$(shell date -u +"%Y-%m-%dT%H:%M:%SZ"))
-BUILD_LDFLAGS=-ldflags "-X $(BUILD_PKG).Version=$(VERSION) -X $(BUILD_PKG).GitHash=$(GIT_HASH) -X $(BUILD_PKG).BuildTime=$(BUILD_TIME)"
+BUILD_LDFLAGS=-ldflags "-X $(BUILD_PKG).Version=$(VERSION) -X $(BUILD_PKG).GitHash=$(GIT_HASH)"
 
 .PHONY: deps
 deps: ## Install all Go dependencies
@@ -45,7 +44,6 @@ build-docker: ## Build Docker image for server
 		--build-arg GO_VERSION=$$GO_VERSION \
 		--build-arg APP_VERSION=$(VERSION) \
 		--build-arg APP_GIT_HASH=$(GIT_HASH) \
-		--build-arg APP_BUILD_TIME=$(BUILD_TIME) \
 		-t paperstacks .
 
 .PHONY: help

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -159,7 +159,6 @@ func banner(w io.Writer, cfg config.Config) {
 	fmt.Fprintln(tw)
 	fmt.Fprintln(tw, "  Version:\t"+build.Version)
 	fmt.Fprintln(tw, "  Git hash:\t"+build.GitHash)
-	fmt.Fprintln(tw, "  Build time:\t"+build.BuildTime)
 	fmt.Fprintln(tw)
 	fmt.Fprintln(tw, "  Hanko API URL:\t"+cfg.HankoAPIURL)
 	fmt.Fprintln(tw, "  Object Storage URL:\t"+storageStatus)

--- a/backend/internal/common/build/build.go
+++ b/backend/internal/common/build/build.go
@@ -2,7 +2,6 @@ package build
 
 var (
 	// These variables are replaced by ldflags at build time
-	Version   = "development"
-	GitHash   = ""
-	BuildTime = "1970-01-01T00:00:00Z" // build date in ISO8601 format
+	Version = "development"
+	GitHash = ""
 )

--- a/backend/internal/web/handler.go
+++ b/backend/internal/web/handler.go
@@ -21,7 +21,6 @@ type pageData struct {
 	Title         string
 	AppVersion    string
 	AppGitHash    string
-	AppBuildTime  string
 	PageName      string
 	NavItems      []navItem
 	AppTargetID   string
@@ -70,7 +69,6 @@ func handleIndex(tmpl *template.Template, navItems []navItem, hankoAPIURL string
 		data := pageData{
 			AppVersion:    build.Version,
 			AppGitHash:    build.GitHash,
-			AppBuildTime:  build.BuildTime,
 			NavItems:      navItems,
 			AppTargetID:   "app-shell",
 			PageContentID: "page-content",

--- a/backend/internal/web/templates/base.html
+++ b/backend/internal/web/templates/base.html
@@ -94,8 +94,10 @@
         </button>
         {{end}}
         <div class="divider"></div>
-        <p class="text-sm text-secondary">{{ .AppVersion}} {{ .AppGitHash }}</p>
-        <p class="text-sm text-secondary">{{ .AppBuildTime}}</p>
+        <p class="text-sm text-secondary">
+          {{ .AppVersion}}
+          <a href="https://github.com/paperstacks-io/paperstacks/commit/{{ .AppGitHash }}">{{ .AppGitHash }}</a>
+        </p>
       </div>
     </aside>
   </div>


### PR DESCRIPTION
This PR removes the build time information.
The build time doesn't provide any value and version + git hash are sufficient to identify build (and make them reproducible).