### PR TITLE
Refactor air config

### DIFF
--- a/backend/.air.toml
+++ b/backend/.air.toml
@@ -7,10 +7,9 @@ tmp_dir = "tmp"
 
 [build]
   args_bin = []
-  bin = "./tmp/server"
-  cmd = "go build -o ./tmp/server ./cmd/server/"
+  cmd = "make build-server"
   delay = 1000
-  entrypoint = ["./tmp/server"]
+  entrypoint = ["./server"]
   exclude_dir = ["assets", "tmp", "vendor", "testdata", "node_modules"]
   exclude_file = []
   exclude_regex = ["_test.go"]


### PR DESCRIPTION
This PR adjusts the air config to use the `make build-server` instead of `go build ...`.
Using `make build-server` provides build flags for version, Git hash, etc. and ensures the same behavior as for a production build.