### PR TITLE
Add changes-saved toast

### DIFF
--- a/backend/internal/web/routes.go
+++ b/backend/internal/web/routes.go
@@ -86,6 +86,7 @@ func AddRoute(
 	// Shared partials
 	mux.Handle(http.MethodGet+" /partials/sidebar-stacks-list", authenticated(handleSidebarStacks(logger, homeTmpl, stackService)))
 	mux.Handle(http.MethodGet+" /partials/toast/not-implemented", defaultMiddle(handlePartialWithoutData(tmpl, "shared/partials/toast/not-implemented")))
+	mux.Handle(http.MethodGet+" /partials/toast/changes-saved", defaultMiddle(handlePartialWithoutData(tmpl, "shared/partials/toast/changes-saved")))
 
 	// Static content
 	mux.Handle(http.MethodGet+" /assets/", defaultMiddle(http.StripPrefix("/assets/", http.FileServerFS(assets))))

--- a/backend/internal/web/templates/shared/partials/toast/changes-saved.html
+++ b/backend/internal/web/templates/shared/partials/toast/changes-saved.html
@@ -1,0 +1,10 @@
+{{ define "shared/partials/toast/changes-saved" }}
+<div
+  class="toast toast-top toast-end animate-[ping_50ms_linear_2s_1_forwards]"
+  onanimationend="if (event.target === this) this.remove()"
+>
+  <div class="alert alert-success alert-soft" role="status" aria-live="polite">
+    <span>Changes saved.</span>
+  </div>
+</div>
+{{ end }}


### PR DESCRIPTION
This PR adds a reusable changes-saved toast, similar to the not-implemented toast.