### PR TITLE
Refactor stack not found handling

### DIFF
--- a/backend/internal/web/handler_stacks.go
+++ b/backend/internal/web/handler_stacks.go
@@ -17,6 +17,8 @@ import (
 
 const invalidStackNameMessage = "Stack name must be 1-80 characters and contain only letters, numbers, spaces, or - _ . , : ' & / ( ) + #."
 
+const stacksPageURL = "/app/stacks/page"
+
 type papersListData struct {
 	Items         []paperDomain.Paper
 	Total         int
@@ -77,15 +79,16 @@ func handleStacksDetailPage(
 			session = &commonauth.Session{}
 		}
 
-		if id == "" {
-			http.Error(w, "missing stack uuid", http.StatusBadRequest)
-			return
-		}
-
 		stack, err := stackService.GetByUUID(ctx, id)
 		if err != nil {
-			logger.Error("get stack by UUID", "error", err.Error())
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			if r.Header.Get("HX-Request") == "true" {
+				w.Header().Set("HX-Redirect", stacksPageURL)
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+
+			http.Redirect(w, r, stacksPageURL, http.StatusSeeOther)
+
 			return
 		}
 

--- a/backend/internal/web/handler_test.go
+++ b/backend/internal/web/handler_test.go
@@ -74,6 +74,51 @@ func TestPageNameFromPath(t *testing.T) {
 	}
 }
 
+func TestHandleStacksDetailPageRedirectsToStacksPageWhenStackNotFoundHTMX(t *testing.T) {
+	t.Parallel()
+
+	handler := handleStacksDetailPage(
+		testLogger(),
+		testWebTemplate(t),
+		"",
+		stackApp.NewStackService(stackMemory.NewRepository(), nil, nil),
+	)
+	req := newStackDetailRequest(t, "00000000-0000-4000-8000-000000000000")
+	req.Header.Set("HX-Request", "true")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if got := rr.Header().Get("HX-Redirect"); got != stacksPageURL {
+		t.Fatalf("HX-Redirect = %q, want %q", got, stacksPageURL)
+	}
+}
+
+func TestHandleStacksDetailPageRedirectsToStacksPageWhenStackNotFound(t *testing.T) {
+	t.Parallel()
+
+	handler := handleStacksDetailPage(
+		testLogger(),
+		testWebTemplate(t),
+		"",
+		stackApp.NewStackService(stackMemory.NewRepository(), nil, nil),
+	)
+	req := newStackDetailRequest(t, "00000000-0000-4000-8000-000000000001")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want %d; body: %s", rr.Code, http.StatusSeeOther, rr.Body.String())
+	}
+	if got := rr.Header().Get("Location"); got != stacksPageURL {
+		t.Fatalf("Location = %q, want %q", got, stacksPageURL)
+	}
+}
+
 func TestHandleSidebarStackCreateRedirectsToDetail(t *testing.T) {
 	t.Parallel()
 
@@ -168,6 +213,20 @@ func newSidebarStackCreateRequest(t *testing.T, userID string, email string, nam
 	req = req.WithContext(commonauth.ContextWithSession(req.Context(), &commonauth.Session{
 		UserID:  userID,
 		Email:   email,
+		IsValid: true,
+	}))
+
+	return req
+}
+
+func newStackDetailRequest(t *testing.T, stackUUID string) *http.Request {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/app/stacks/detail/"+stackUUID, nil)
+	req.SetPathValue("uuid", stackUUID)
+	req = req.WithContext(commonauth.ContextWithSession(req.Context(), &commonauth.Session{
+		UserID:  "owner-detail",
+		Email:   "detail@example.com",
 		IsValid: true,
 	}))
 


### PR DESCRIPTION
This PR changes the handling when a stack can't be resolved by its `UUID`.
Instead of causing a sever error a user will be redirected to the `Stacks Overview` page. The redirect behavior ensures a better user experience, e.g., in case bookmark to a deleted stack is opened.