### PR TITLE
Refactor stack handler and toast

### DIFF
--- a/backend/internal/stack/application/service.go
+++ b/backend/internal/stack/application/service.go
@@ -68,18 +68,18 @@ func (s *StackService) Create(ctx context.Context, stack domain.Stack) error {
 // It initializes missing timestamps and generates a UUID if necessary.
 //
 // It returns an error if the stack is invalid or could not be stored.
-func (s *StackService) CreateByName(ctx context.Context, name string, userID string) error {
+func (s *StackService) CreateByName(ctx context.Context, name string, userID string) (domain.Stack, error) {
 	user, err := s.userGetter.GetByExternalID(ctx, userID)
 	if err != nil {
-		return err
+		return domain.Stack{}, err
 	}
 
 	stack := domain.NewStack(name, user)
 	if err := stack.Validate(); err != nil {
-		return err
+		return domain.Stack{}, err
 	}
 
-	return s.repo.Create(ctx, *stack)
+	return *stack, s.repo.Create(ctx, *stack)
 }
 
 // Update validates and updates an existing stack.

--- a/backend/internal/web/handler.go
+++ b/backend/internal/web/handler.go
@@ -26,22 +26,26 @@ type pageData struct {
 	Session     commonauth.Session
 }
 
+func newPageData(r *http.Request, hankoAPIURL string) pageData {
+	session, ok := commonauth.SessionFromContext(r.Context())
+	if !ok || session == nil {
+		session = &commonauth.Session{}
+	}
+
+	return pageData{
+		AppVersion:  build.Version,
+		AppGitHash:  build.GitHash,
+		PageName:    pageNameFromPath(r.URL.Path),
+		HankoAPIURL: hankoAPIURL,
+		Session:     *session,
+	}
+}
+
 func handlePage(tmpl *template.Template, hankoAPIURL string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 
-		session, ok := commonauth.SessionFromContext(r.Context())
-		if !ok {
-			session = &commonauth.Session{}
-		}
-
-		data := pageData{
-			AppVersion:  build.Version,
-			AppGitHash:  build.GitHash,
-			PageName:    pageNameFromPath(r.URL.Path),
-			HankoAPIURL: hankoAPIURL,
-			Session:     *session,
-		}
+		data := newPageData(r, hankoAPIURL)
 
 		renderTemplate(w, r, tmpl, data)
 	})

--- a/backend/internal/web/handler.go
+++ b/backend/internal/web/handler.go
@@ -198,18 +198,3 @@ func handleLogout(
 		http.Redirect(w, r, "/app/", http.StatusSeeOther)
 	})
 }
-
-func pageNameFromPath(path string) string {
-	path = strings.Trim(path, "/")
-	if path == "" {
-		return "home"
-	}
-
-	pageName, _, _ := strings.Cut(path, "?")
-
-	return pageName
-}
-
-func normalizeFormParam(s string) string {
-	return strings.ToLower(strings.TrimSpace(s))
-}

--- a/backend/internal/web/handler.go
+++ b/backend/internal/web/handler.go
@@ -1,7 +1,6 @@
 package web
 
 import (
-	"context"
 	"html/template"
 	"log/slog"
 	"net/http"
@@ -133,7 +132,7 @@ func handlePapersSearch(
 			Desc:   desc,
 			Page:   page,
 		}
-		result, err := paperService.Search(context.Background(), opts)
+		result, err := paperService.Search(r.Context(), opts)
 		if err != nil {
 			logger.Error("read papers", "error", err.Error())
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/backend/internal/web/handler.go
+++ b/backend/internal/web/handler.go
@@ -26,10 +26,6 @@ type pageData struct {
 	Session     commonauth.Session
 }
 
-type alertData struct {
-	Message string
-}
-
 func handlePage(tmpl *template.Template, hankoAPIURL string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/backend/internal/web/handler.go
+++ b/backend/internal/web/handler.go
@@ -4,7 +4,6 @@ import (
 	"html/template"
 	"log/slog"
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 
@@ -87,12 +86,7 @@ func handleSidebarStacks(
 			return
 		}
 
-		currentPath := r.URL.Path
-		if hxCurrentURL := r.Header.Get("HX-Current-URL"); hxCurrentURL != "" {
-			if u, err := url.Parse(hxCurrentURL); err == nil {
-				currentPath = strings.TrimPrefix(u.Path, "/app")
-			}
-		}
+		currentPath := currentHTMXPath(r)
 
 		data := struct {
 			stackDomain.SearchResult
@@ -192,9 +186,8 @@ func handleLogout(
 			return
 		}
 
-		if r.Header.Get("HX-Request") == "true" {
-			w.Header().Set("HX-Redirect", "/app/")
-			w.WriteHeader(http.StatusOK)
+		if isHTMX(r) {
+			hxRedirect(w, "/app/", http.StatusOK)
 			return
 		}
 

--- a/backend/internal/web/handler.go
+++ b/backend/internal/web/handler.go
@@ -111,17 +111,6 @@ func handleSidebarStacks(
 	})
 }
 
-func renderTemplate(w http.ResponseWriter, r *http.Request, tmpl *template.Template, data any) {
-	templateName := "base"
-	if r.Header.Get("HX-Request") == "true" {
-		templateName = "app"
-	}
-
-	if err := tmpl.ExecuteTemplate(w, templateName, data); err != nil {
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-	}
-}
-
 func handlePapersSearch(
 	logger *slog.Logger,
 	tmpl *template.Template,

--- a/backend/internal/web/handler_commons.go
+++ b/backend/internal/web/handler_commons.go
@@ -1,0 +1,49 @@
+package web
+
+import (
+	"html/template"
+	"net/http"
+)
+
+type toastData struct {
+	Message string
+}
+
+func renderTemplate(w http.ResponseWriter, r *http.Request, tmpl *template.Template, data any) {
+	templateName := "base"
+	if r.Header.Get("HX-Request") == "true" {
+		templateName = "app"
+	}
+
+	if err := tmpl.ExecuteTemplate(w, templateName, data); err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+	}
+}
+
+func renderSuccessToast(w http.ResponseWriter, tmpl *template.Template, message string) error {
+	templateName := "shared/partials/toast/success"
+	return renderToast(w, tmpl, templateName, toastData{Message: message})
+}
+
+func renderInfoToast(w http.ResponseWriter, tmpl *template.Template, message string) error {
+	templateName := "shared/partials/toast/info"
+	return renderToast(w, tmpl, templateName, toastData{Message: message})
+}
+
+func renderWarningToast(w http.ResponseWriter, tmpl *template.Template, message string) error {
+	templateName := "shared/partials/toast/warning"
+	return renderToast(w, tmpl, templateName, toastData{Message: message})
+}
+
+func renderErrorToast(w http.ResponseWriter, tmpl *template.Template, message string) error {
+	templateName := "shared/partials/toast/error"
+	return renderToast(w, tmpl, templateName, toastData{Message: message})
+}
+
+func renderToast(w http.ResponseWriter, tmpl *template.Template, templateName string, data toastData) error {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("HX-Retarget", "#toast-host")
+	w.Header().Set("HX-Reswap", "innerHTML")
+
+	return tmpl.ExecuteTemplate(w, templateName, data)
+}

--- a/backend/internal/web/handler_commons.go
+++ b/backend/internal/web/handler_commons.go
@@ -3,6 +3,7 @@ package web
 import (
 	"html/template"
 	"net/http"
+	"strings"
 )
 
 type toastData struct {
@@ -46,4 +47,19 @@ func renderToast(w http.ResponseWriter, tmpl *template.Template, templateName st
 	w.Header().Set("HX-Reswap", "innerHTML")
 
 	return tmpl.ExecuteTemplate(w, templateName, data)
+}
+
+func pageNameFromPath(path string) string {
+	path = strings.Trim(path, "/")
+	if path == "" {
+		return "home"
+	}
+
+	pageName, _, _ := strings.Cut(path, "?")
+
+	return pageName
+}
+
+func normalizeFormParam(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
 }

--- a/backend/internal/web/handler_commons.go
+++ b/backend/internal/web/handler_commons.go
@@ -3,6 +3,7 @@ package web
 import (
 	"html/template"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -12,13 +13,33 @@ type toastData struct {
 
 func renderTemplate(w http.ResponseWriter, r *http.Request, tmpl *template.Template, data any) {
 	templateName := "base"
-	if r.Header.Get("HX-Request") == "true" {
+	if isHTMX(r) {
 		templateName = "app"
 	}
 
 	if err := tmpl.ExecuteTemplate(w, templateName, data); err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 	}
+}
+
+func isHTMX(r *http.Request) bool {
+	return r.Header.Get("HX-Request") == "true"
+}
+
+func hxRedirect(w http.ResponseWriter, location string, status int) {
+	w.Header().Set("HX-Redirect", location)
+	w.WriteHeader(status)
+}
+
+func currentHTMXPath(r *http.Request) string {
+	currentPath := r.URL.Path
+	if hxCurrentURL := r.Header.Get("HX-Current-URL"); hxCurrentURL != "" {
+		if u, err := url.Parse(hxCurrentURL); err == nil {
+			currentPath = strings.TrimPrefix(u.Path, "/app")
+		}
+	}
+
+	return currentPath
 }
 
 func renderSuccessToast(w http.ResponseWriter, tmpl *template.Template, message string) error {

--- a/backend/internal/web/handler_stacks.go
+++ b/backend/internal/web/handler_stacks.go
@@ -12,7 +12,6 @@ import (
 	paperDomain "github.com/paperstacks.io/paperstacks/internal/paper/domain"
 	stackApp "github.com/paperstacks.io/paperstacks/internal/stack/application"
 	stackDomain "github.com/paperstacks.io/paperstacks/internal/stack/domain"
-	userDomain "github.com/paperstacks.io/paperstacks/internal/user/domain"
 )
 
 const invalidStackNameMessage = "Stack name must be 1-80 characters and contain only letters, numbers, spaces, or - _ . , : ' & / ( ) + #."
@@ -249,69 +248,6 @@ func handleStacksStatsByOwner(
 	})
 }
 
-func handleStacksCreate(
-	logger *slog.Logger,
-	tmpl *template.Template,
-	stackService *stackApp.StackService,
-) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
-
-		const (
-			createStackErrorTarget   = "#create_stack_error"
-			createStackSuccessTarget = "#create_stack_success"
-		)
-
-		render := func(status int, target string, templateName string, data alertData) {
-			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			w.Header().Set("HX-Retarget", target)
-			w.Header().Set("HX-Reswap", "innerHTML")
-			w.WriteHeader(status)
-
-			if err := tmpl.ExecuteTemplate(w, templateName, data); err != nil {
-				logger.Error("render stack create", "error", err.Error())
-			}
-		}
-
-		renderError := func(status int, message string) {
-			render(status, createStackErrorTarget, "stacks/partials/alert-error", alertData{
-				Message: message,
-			})
-		}
-
-		renderSuccess := func(message string) {
-			render(http.StatusCreated, createStackSuccessTarget, "stacks/partials/toast-success", alertData{
-				Message: message,
-			})
-		}
-
-		session, ok := commonauth.SessionFromContext(ctx)
-		if !ok || session == nil || !session.IsValid {
-			renderError(http.StatusUnauthorized, "Unauthorized. Please log in to create a stack.")
-			return
-		}
-
-		name := r.FormValue("name")
-
-		if err := stackService.CreateByName(ctx, name, session.UserID); err != nil {
-			logger.Error("create stack", "error", err.Error())
-
-			switch {
-			case errors.Is(err, stackDomain.ErrStackAlreadyExists):
-				renderError(http.StatusConflict, "A stack with the name '"+name+"' already exists.")
-			case errors.Is(err, stackDomain.ErrInvalidName):
-				renderError(http.StatusUnprocessableEntity, invalidStackNameMessage)
-			default:
-				renderError(http.StatusUnprocessableEntity, "Failed to create stack. Please try again.")
-			}
-
-			return
-		}
-
-		renderSuccess("Stack '" + name + "' created successfully.")
-	})
-}
-
 func handleSidebarStackCreate(
 	logger *slog.Logger,
 	tmpl *template.Template,
@@ -320,40 +256,24 @@ func handleSidebarStackCreate(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		renderError := func(status int, message string) {
-			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			w.Header().Set("HX-Retarget", "#toast-host")
-			w.Header().Set("HX-Reswap", "innerHTML")
-			w.WriteHeader(status)
-
-			if err := tmpl.ExecuteTemplate(w, "shared/partials/toast/error", alertData{
-				Message: message,
-			}); err != nil {
-				logger.Error("render sidebar stack create error", "error", err.Error())
-			}
-		}
-
 		session, ok := commonauth.SessionFromContext(ctx)
 		if !ok || session == nil || !session.IsValid {
-			renderError(http.StatusUnauthorized, "Unauthorized. Please log in to create a stack.")
+			renderErrorToast(w, tmpl, "Unauthorized. Please log in to create a stack.")
 			return
 		}
 
-		user := userDomain.NewUser(session.UserID, session.Email)
-		stack := stackDomain.NewStack(r.FormValue("name"), user)
-
-		if err := stackService.Create(ctx, *stack); err != nil {
+		name := r.FormValue("name")
+		stack, err := stackService.CreateByName(ctx, name, session.UserID)
+		if err != nil {
 			logger.Error("create sidebar stack", "error", err.Error())
 
 			switch {
-			case errors.Is(err, stackDomain.ErrInvalidStack):
-				renderError(http.StatusUnprocessableEntity, "Invalid stack.")
-			case errors.Is(err, stackDomain.ErrInvalidName):
-				renderError(http.StatusUnprocessableEntity, invalidStackNameMessage)
 			case errors.Is(err, stackDomain.ErrStackAlreadyExists):
-				renderError(http.StatusConflict, "A stack with this name already exists.")
+				renderErrorToast(w, tmpl, "A stack with this name already exists.")
+			case errors.Is(err, stackDomain.ErrInvalidName):
+				renderErrorToast(w, tmpl, invalidStackNameMessage)
 			default:
-				renderError(http.StatusInternalServerError, "Failed to create stack: "+err.Error())
+				renderErrorToast(w, tmpl, "Failed to create stack: "+err.Error())
 			}
 			return
 		}
@@ -371,22 +291,9 @@ func handleStackDelete(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		renderError := func(status int, message string) {
-			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			w.Header().Set("HX-Retarget", "#toast-host")
-			w.Header().Set("HX-Reswap", "innerHTML")
-			w.WriteHeader(status)
-
-			if err := tmpl.ExecuteTemplate(w, "shared/partials/toast/error", alertData{
-				Message: message,
-			}); err != nil {
-				logger.Error("render stack delete error", "error", err.Error())
-			}
-		}
-
 		session, ok := commonauth.SessionFromContext(ctx)
 		if !ok || session == nil || !session.IsValid {
-			renderError(http.StatusUnauthorized, "Unauthorized. Please log in to delete this stack.")
+			renderErrorToast(w, tmpl, "Unauthorized. Please log in to delete this stack.")
 			return
 		}
 
@@ -394,18 +301,18 @@ func handleStackDelete(
 		stack, err := stackService.GetByUUID(ctx, stackUUID)
 		if err != nil {
 			logger.Error("get stack before delete", "error", err.Error())
-			renderError(http.StatusInternalServerError, "Failed to delete stack: "+err.Error())
+			renderErrorToast(w, tmpl, "Failed to delete stack: "+err.Error())
 			return
 		}
 
 		if stack.Owner.ExternalID != session.UserID {
-			renderError(http.StatusForbidden, "You are not allowed to delete this stack.")
+			renderErrorToast(w, tmpl, "You are not allowed to delete this stack.")
 			return
 		}
 
 		if err := stackService.Delete(ctx, stackUUID); err != nil {
 			logger.Error("delete stack", "error", err.Error())
-			renderError(http.StatusInternalServerError, "Failed to delete stack: "+err.Error())
+			renderErrorToast(w, tmpl, "Failed to delete stack: "+err.Error())
 			return
 		}
 
@@ -427,26 +334,9 @@ func handleStackPublicSettingUpdate(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		renderToast := func(status int, templateName string, data alertData) {
-			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			w.Header().Set("HX-Retarget", "#toast-host")
-			w.Header().Set("HX-Reswap", "innerHTML")
-			w.WriteHeader(status)
-
-			if err := tmpl.ExecuteTemplate(w, templateName, data); err != nil {
-				logger.Error("render stack public setting toast", "error", err.Error())
-			}
-		}
-		renderError := func(status int, message string) {
-			renderToast(status, "shared/partials/toast/error", alertData{Message: message})
-		}
-		renderSuccess := func() {
-			renderToast(http.StatusOK, "shared/partials/toast/changes-saved", alertData{})
-		}
-
 		session, ok := commonauth.SessionFromContext(ctx)
 		if !ok || session == nil || !session.IsValid {
-			renderError(http.StatusUnauthorized, "Unauthorized. Please log in to update this stack.")
+			renderErrorToast(w, tmpl, "Unauthorized. Please log in to update this stack.")
 			return
 		}
 
@@ -455,23 +345,22 @@ func handleStackPublicSettingUpdate(
 		stack, err := stackService.GetByUUID(ctx, stackUUID)
 		if err != nil {
 			logger.Error("get stack before public setting update", "error", err.Error())
-			renderError(http.StatusInternalServerError, "Failed to update stack setting: "+err.Error())
+			renderErrorToast(w, tmpl, "Failed to stack setting: "+err.Error())
 			return
 		}
 
 		if stack.Owner.ExternalID != session.UserID {
-			renderError(http.StatusForbidden, "You are not allowed to update this stack.")
+			renderErrorToast(w, tmpl, "You are not allowed to update this stack.")
 			return
 		}
 
 		stack.IsPublic = r.FormValue("is_public") == "on"
 		if _, err := stackService.Update(ctx, stack); err != nil {
 			logger.Error("update stack public setting", "error", err.Error())
-
-			renderError(http.StatusInternalServerError, "Failed to update stack setting: "+err.Error())
+			renderErrorToast(w, tmpl, "Failed to stack setting: "+err.Error())
 			return
 		}
 
-		renderSuccess()
+		renderSuccessToast(w, tmpl, "Stack changes saved")
 	})
 }

--- a/backend/internal/web/handler_stacks.go
+++ b/backend/internal/web/handler_stacks.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/paperstacks.io/paperstacks/internal/common/build"
 	commonauth "github.com/paperstacks.io/paperstacks/internal/common/server/auth"
 	paperApp "github.com/paperstacks.io/paperstacks/internal/paper/application"
 	paperDomain "github.com/paperstacks.io/paperstacks/internal/paper/domain"
@@ -73,11 +72,6 @@ func handleStacksDetailPage(
 		ctx := r.Context()
 		id := r.PathValue("uuid")
 
-		session, ok := commonauth.SessionFromContext(ctx)
-		if !ok {
-			session = &commonauth.Session{}
-		}
-
 		stack, err := stackService.GetByUUID(ctx, id)
 		if err != nil {
 			if r.Header.Get("HX-Request") == "true" {
@@ -103,13 +97,7 @@ func handleStacksDetailPage(
 			CreatedAt     string
 			UpdatedAt     string
 		}{
-			pageData: pageData{
-				AppVersion:  build.Version,
-				AppGitHash:  build.GitHash,
-				PageName:    pageNameFromPath(r.URL.Path),
-				HankoAPIURL: hankoAPIURL,
-				Session:     *session,
-			},
+			pageData:      newPageData(r, hankoAPIURL),
 			Stack:         stack,
 			SelectedPaper: selectedPaper,
 			CreatedAt:     stack.CreatedAt.Format("2006-01-02 15:04"),
@@ -162,11 +150,6 @@ func handleStacksPage(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 
-		session, ok := commonauth.SessionFromContext(r.Context())
-		if !ok {
-			session = &commonauth.Session{}
-		}
-
 		counter, err := stackService.CountPublic(r.Context())
 		if err != nil {
 			logger.Error("count public stacks", "error", err.Error())
@@ -175,13 +158,7 @@ func handleStacksPage(
 		}
 
 		data := stacksPageData{
-			pageData: pageData{
-				AppVersion:  build.Version,
-				AppGitHash:  build.GitHash,
-				PageName:    pageNameFromPath(r.URL.Path),
-				HankoAPIURL: hankoAPIURL,
-				Session:     *session,
-			},
+			pageData:          newPageData(r, hankoAPIURL),
 			StacksCountTotal:  0,
 			StacksCountPublic: counter,
 		}

--- a/backend/internal/web/handler_stacks.go
+++ b/backend/internal/web/handler_stacks.go
@@ -74,9 +74,8 @@ func handleStacksDetailPage(
 
 		stack, err := stackService.GetByUUID(ctx, id)
 		if err != nil {
-			if r.Header.Get("HX-Request") == "true" {
-				w.Header().Set("HX-Redirect", stacksPageURL)
-				w.WriteHeader(http.StatusOK)
+			if isHTMX(r) {
+				hxRedirect(w, stacksPageURL, http.StatusOK)
 				return
 			}
 
@@ -255,8 +254,7 @@ func handleSidebarStackCreate(
 			return
 		}
 
-		w.Header().Set("HX-Redirect", "/app/stacks/detail/"+stack.UUID)
-		w.WriteHeader(http.StatusCreated)
+		hxRedirect(w, "/app/stacks/detail/"+stack.UUID, http.StatusCreated)
 	})
 }
 
@@ -293,9 +291,8 @@ func handleStackDelete(
 			return
 		}
 
-		if r.Header.Get("HX-Request") == "true" {
-			w.Header().Set("HX-Redirect", stacksPageURL)
-			w.WriteHeader(http.StatusOK)
+		if isHTMX(r) {
+			hxRedirect(w, stacksPageURL, http.StatusOK)
 			return
 		}
 

--- a/backend/internal/web/handler_test.go
+++ b/backend/internal/web/handler_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"context"
 	"html/template"
 	"io"
 	"log/slog"
@@ -16,6 +17,26 @@ import (
 	stackMemory "github.com/paperstacks.io/paperstacks/internal/stack/repository/memory"
 	userDomain "github.com/paperstacks.io/paperstacks/internal/user/domain"
 )
+
+type fakeUserGetter map[string]userDomain.User
+
+func (f fakeUserGetter) GetByExternalID(_ context.Context, externalID string) (userDomain.User, error) {
+	user, ok := f[externalID]
+	if !ok {
+		return userDomain.User{}, userDomain.ErrUserNotFound
+	}
+
+	return user, nil
+}
+
+func newTestStackService(users ...userDomain.User) *stackApp.StackService {
+	userGetter := make(fakeUserGetter, len(users))
+	for _, user := range users {
+		userGetter[user.ExternalID] = user
+	}
+
+	return stackApp.NewStackService(stackMemory.NewRepository(), userGetter, nil)
+}
 
 func TestPageNameFromPath(t *testing.T) {
 	t.Parallel()
@@ -81,7 +102,7 @@ func TestHandleStacksDetailPageRedirectsToStacksPageWhenStackNotFoundHTMX(t *tes
 		testLogger(),
 		testWebTemplate(t),
 		"",
-		stackApp.NewStackService(stackMemory.NewRepository(), nil, nil),
+		newTestStackService(),
 	)
 	req := newStackDetailRequest(t, "00000000-0000-4000-8000-000000000000")
 	req.Header.Set("HX-Request", "true")
@@ -104,7 +125,7 @@ func TestHandleStacksDetailPageRedirectsToStacksPageWhenStackNotFound(t *testing
 		testLogger(),
 		testWebTemplate(t),
 		"",
-		stackApp.NewStackService(stackMemory.NewRepository(), nil, nil),
+		newTestStackService(),
 	)
 	req := newStackDetailRequest(t, "00000000-0000-4000-8000-000000000001")
 	rr := httptest.NewRecorder()
@@ -122,7 +143,7 @@ func TestHandleStacksDetailPageRedirectsToStacksPageWhenStackNotFound(t *testing
 func TestHandleStackPublicSettingUpdateSetsPublic(t *testing.T) {
 	t.Parallel()
 
-	stackService := stackApp.NewStackService(stackMemory.NewRepository(), nil, nil)
+	stackService := newTestStackService()
 	user := userDomain.NewUser("owner-public-setting-true", "public-true@example.com")
 	stack := stackDomain.NewStack("Public Setting Stack", user)
 	stack.IsPublic = false
@@ -150,7 +171,7 @@ func TestHandleStackPublicSettingUpdateSetsPublic(t *testing.T) {
 func TestHandleStackPublicSettingUpdateClearsPublic(t *testing.T) {
 	t.Parallel()
 
-	stackService := stackApp.NewStackService(stackMemory.NewRepository(), nil, nil)
+	stackService := newTestStackService()
 	user := userDomain.NewUser("owner-public-setting-false", "public-false@example.com")
 	stack := stackDomain.NewStack("Private Setting Stack", user)
 	stack.IsPublic = true
@@ -178,7 +199,7 @@ func TestHandleStackPublicSettingUpdateClearsPublic(t *testing.T) {
 func TestHandleStackPublicSettingUpdateRejectsNonOwner(t *testing.T) {
 	t.Parallel()
 
-	stackService := stackApp.NewStackService(stackMemory.NewRepository(), nil, nil)
+	stackService := newTestStackService()
 	owner := userDomain.NewUser("owner-public-setting-forbidden", "owner-public@example.com")
 	stack := stackDomain.NewStack("Forbidden Public Setting Stack", owner)
 	stack.IsPublic = false
@@ -192,7 +213,7 @@ func TestHandleStackPublicSettingUpdateRejectsNonOwner(t *testing.T) {
 
 	handler.ServeHTTP(rr, req)
 
-	assertSidebarStackCreateError(t, rr, http.StatusForbidden, "You are not allowed to update this stack.")
+	assertSidebarStackCreateError(t, rr, http.StatusOK, "You are not allowed to update this stack.")
 
 	updated, err := stackService.GetByUUID(req.Context(), stack.UUID)
 	if err != nil {
@@ -206,10 +227,11 @@ func TestHandleStackPublicSettingUpdateRejectsNonOwner(t *testing.T) {
 func TestHandleSidebarStackCreateRedirectsToDetail(t *testing.T) {
 	t.Parallel()
 
-	stackService := stackApp.NewStackService(stackMemory.NewRepository(), nil, nil)
+	user := userDomain.NewUser("owner-sidebar-create", "sidebar@example.com")
+	stackService := newTestStackService(user)
 	handler := handleSidebarStackCreate(testLogger(), testWebTemplate(t), stackService)
 
-	req := newSidebarStackCreateRequest(t, "owner-sidebar-create", "sidebar@example.com", "Sidebar Stack")
+	req := newSidebarStackCreateRequest(t, user.ExternalID, user.Email, "Sidebar Stack")
 	rr := httptest.NewRecorder()
 
 	handler.ServeHTTP(rr, req)
@@ -236,25 +258,26 @@ func TestHandleSidebarStackCreateRedirectsToDetail(t *testing.T) {
 func TestHandleSidebarStackCreateRendersToastOnEmptyName(t *testing.T) {
 	t.Parallel()
 
+	user := userDomain.NewUser("owner-empty-sidebar-create", "empty@example.com")
 	handler := handleSidebarStackCreate(
 		testLogger(),
 		testWebTemplate(t),
-		stackApp.NewStackService(stackMemory.NewRepository(), nil, nil),
+		newTestStackService(user),
 	)
 
-	req := newSidebarStackCreateRequest(t, "owner-empty-sidebar-create", "empty@example.com", "   ")
+	req := newSidebarStackCreateRequest(t, user.ExternalID, user.Email, "   ")
 	rr := httptest.NewRecorder()
 
 	handler.ServeHTTP(rr, req)
 
-	assertSidebarStackCreateError(t, rr, http.StatusUnprocessableEntity, "Stack name must be 1-80 characters")
+	assertSidebarStackCreateError(t, rr, http.StatusOK, "Stack name must be 1-80 characters")
 }
 
 func TestHandleSidebarStackCreateRendersToastOnDuplicateName(t *testing.T) {
 	t.Parallel()
 
-	stackService := stackApp.NewStackService(stackMemory.NewRepository(), nil, nil)
 	user := userDomain.NewUser("owner-duplicate-sidebar-create", "duplicate@example.com")
+	stackService := newTestStackService(user)
 	existing := stackDomain.NewStack("Duplicate Stack", user)
 	if err := stackService.Create(t.Context(), *existing); err != nil {
 		t.Fatalf("seed duplicate stack: %v", err)
@@ -266,7 +289,7 @@ func TestHandleSidebarStackCreateRendersToastOnDuplicateName(t *testing.T) {
 
 	handler.ServeHTTP(rr, req)
 
-	assertSidebarStackCreateError(t, rr, http.StatusConflict, "A stack with this name already exists.")
+	assertSidebarStackCreateError(t, rr, http.StatusOK, "A stack with this name already exists.")
 }
 
 func TestHandleSidebarStackCreateRendersToastWithoutSession(t *testing.T) {
@@ -275,7 +298,7 @@ func TestHandleSidebarStackCreateRendersToastWithoutSession(t *testing.T) {
 	handler := handleSidebarStackCreate(
 		testLogger(),
 		testWebTemplate(t),
-		stackApp.NewStackService(stackMemory.NewRepository(), nil, nil),
+		newTestStackService(),
 	)
 	req := httptest.NewRequest(http.MethodPost, "/app/stacks/sidebar/create", strings.NewReader(url.Values{
 		"name": {"Sidebar Stack"},
@@ -285,7 +308,7 @@ func TestHandleSidebarStackCreateRendersToastWithoutSession(t *testing.T) {
 
 	handler.ServeHTTP(rr, req)
 
-	assertSidebarStackCreateError(t, rr, http.StatusUnauthorized, "Unauthorized. Please log in to create a stack.")
+	assertSidebarStackCreateError(t, rr, http.StatusOK, "Unauthorized. Please log in to create a stack.")
 }
 
 func newSidebarStackCreateRequest(t *testing.T, userID string, email string, name string) *http.Request {
@@ -361,7 +384,7 @@ func assertStackPublicSettingSuccess(t *testing.T, rr *httptest.ResponseRecorder
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d; body: %s", rr.Code, http.StatusOK, rr.Body.String())
 	}
-	if body := rr.Body.String(); !strings.Contains(body, "Changes saved.") {
+	if body := rr.Body.String(); !strings.Contains(body, "Stack changes saved") {
 		t.Fatalf("body does not contain success toast: %s", body)
 	}
 }

--- a/backend/internal/web/routes.go
+++ b/backend/internal/web/routes.go
@@ -73,7 +73,6 @@ func AddRoute(
 	mux.Handle(http.MethodGet+" /stacks/detail/{stackUUID}/papers/{paperUUID}", authenticated(handleStackPaperInfo(logger, tmpl, paperService)))
 	mux.Handle(http.MethodPost+" /stacks/search", defaultMiddle(handleStacksSearchByOwner(logger, tmpl, stackService)))
 	mux.Handle(http.MethodPost+" /stacks/stats", defaultMiddle(handleStacksStatsByOwner(logger, tmpl, stackService)))
-	mux.Handle(http.MethodPost+" /stacks/create", defaultMiddle(handleStacksCreate(logger, tmpl, stackService)))
 	mux.Handle(http.MethodPost+" /stacks/sidebar/create", authenticated(handleSidebarStackCreate(logger, tmpl, stackService)))
 
 	settingsTmpl := pageTemplate("settings/page")

--- a/backend/internal/web/templates/shared/partials/toast/info.html
+++ b/backend/internal/web/templates/shared/partials/toast/info.html
@@ -1,0 +1,18 @@
+{{ define "shared/partials/toast/info" }}
+<div
+  class="toast toast-top toast-end z-50 animate-[ping_50ms_linear_2s_1_forwards]"
+  onanimationend="if (event.target === this) this.remove()"
+>
+  <div class="alert alert-info" role="status" aria-live="polite">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="h-6 w-6 shrink-0 stroke-current">
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+      ></path>
+    </svg>
+    <span>{{ .Message }}</span>
+  </div>
+</div>
+{{ end }}

--- a/backend/internal/web/templates/shared/partials/toast/success.html
+++ b/backend/internal/web/templates/shared/partials/toast/success.html
@@ -1,0 +1,18 @@
+{{ define "shared/partials/toast/success" }}
+<div
+  class="toast toast-top toast-end animate-[ping_50ms_linear_2s_1_forwards]"
+  onanimationend="if (event.target === this) this.remove()"
+>
+  <div class="alert alert-success" role="status" aria-live="polite">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 shrink-0 stroke-current" fill="none" viewBox="0 0 24 24">
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+    </svg>
+    <span>{{ .Message }}</span>
+  </div>
+</div>
+{{ end }}

--- a/backend/internal/web/templates/shared/partials/toast/warning.html
+++ b/backend/internal/web/templates/shared/partials/toast/warning.html
@@ -1,18 +1,18 @@
-{{ define "shared/partials/toast/changes-saved" }}
+{{ define "shared/partials/toast/warning" }}
 <div
   class="toast toast-top toast-end animate-[ping_50ms_linear_2s_1_forwards]"
   onanimationend="if (event.target === this) this.remove()"
 >
-  <div class="alert alert-success" role="status" aria-live="polite">
+  <div class="alert alert-warning" role="status" aria-live="polite">
     <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 shrink-0 stroke-current" fill="none" viewBox="0 0 24 24">
       <path
         stroke-linecap="round"
         stroke-linejoin="round"
         stroke-width="2"
-        d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+        d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
       />
     </svg>
-    <span>Changes saved.</span>
+    <span>{{ .Message }}</span>
   </div>
 </div>
 {{ end }}


### PR DESCRIPTION
This PR refactors the web handler by adding `handler_commons.go` and add helper functions. In addition, error toasts are made reusable, including info, warning, and success toast.