### PR TITLE
Add remove paper from stack to UI

### DIFF
--- a/backend/internal/web/handler_stacks.go
+++ b/backend/internal/web/handler_stacks.go
@@ -300,6 +300,51 @@ func handleStackDelete(
 	})
 }
 
+func handleStackPaperRemove(
+	logger *slog.Logger,
+	tmpl *template.Template,
+	stackService *stackApp.StackService,
+) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		session, ok := commonauth.SessionFromContext(ctx)
+		if !ok || session == nil || !session.IsValid {
+			renderErrorToast(w, tmpl, "Unauthorized. Please log in to remove papers from this stack.")
+			return
+		}
+
+		stackUUID := r.PathValue("uuid")
+		paperUUID := r.PathValue("paperUUID")
+
+		stack, err := stackService.GetByUUID(ctx, stackUUID)
+		if err != nil {
+			logger.Error("get stack before paper removal", "stackUUID", stackUUID, "error", err.Error())
+			renderErrorToast(w, tmpl, "Failed to remove paper from stack: "+err.Error())
+			return
+		}
+
+		if stack.Owner.ExternalID != session.UserID {
+			renderErrorToast(w, tmpl, "You are not allowed to remove papers from this stack.")
+			return
+		}
+
+		if err := stackService.RemovePaper(ctx, stackUUID, paperUUID); err != nil {
+			logger.Error("remove paper from stack", "stackUUID", stackUUID, "paperUUID", paperUUID, "error", err.Error())
+			renderErrorToast(w, tmpl, "Failed to remove paper from stack: "+err.Error())
+			return
+		}
+
+		detailURL := "/app/stacks/detail/" + stackUUID
+		if isHTMX(r) {
+			hxRedirect(w, detailURL, http.StatusOK)
+			return
+		}
+
+		http.Redirect(w, r, detailURL, http.StatusSeeOther)
+	})
+}
+
 func handleStackPublicSettingUpdate(
 	logger *slog.Logger,
 	tmpl *template.Template,

--- a/backend/internal/web/handler_test.go
+++ b/backend/internal/web/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	commonauth "github.com/paperstacks.io/paperstacks/internal/common/server/auth"
+	paperDomain "github.com/paperstacks.io/paperstacks/internal/paper/domain"
 	stackApp "github.com/paperstacks.io/paperstacks/internal/stack/application"
 	stackDomain "github.com/paperstacks.io/paperstacks/internal/stack/domain"
 	stackMemory "github.com/paperstacks.io/paperstacks/internal/stack/repository/memory"
@@ -224,6 +225,76 @@ func TestHandleStackPublicSettingUpdateRejectsNonOwner(t *testing.T) {
 	}
 }
 
+func TestHandleStackPaperRemoveRemovesPaperAndRedirectsToDetail(t *testing.T) {
+	t.Parallel()
+
+	stackService := newTestStackService()
+	user := userDomain.NewUser("owner-paper-remove", "paper-remove@example.com")
+	stack := stackDomain.NewStack("Paper Remove Stack", user)
+	removedPaperUUID := "11111111-1111-4111-8111-111111111111"
+	retainedPaperUUID := "22222222-2222-4222-8222-222222222222"
+	stack.Papers = []paperDomain.Paper{
+		{UUID: removedPaperUUID, Title: "Removed Paper"},
+		{UUID: retainedPaperUUID, Title: "Retained Paper"},
+	}
+	if err := stackService.Create(t.Context(), *stack); err != nil {
+		t.Fatalf("seed stack: %v", err)
+	}
+
+	handler := handleStackPaperRemove(testLogger(), testWebTemplate(t), stackService)
+	req := newStackPaperRemoveRequest(t, stack.UUID, removedPaperUUID, user.ExternalID, user.Email)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if got := rr.Header().Get("HX-Redirect"); got != "/app/stacks/detail/"+stack.UUID {
+		t.Fatalf("HX-Redirect = %q, want detail page redirect", got)
+	}
+
+	updated, err := stackService.GetByUUID(req.Context(), stack.UUID)
+	if err != nil {
+		t.Fatalf("GetByUUID() error = %v", err)
+	}
+	if len(updated.Papers) != 1 {
+		t.Fatalf("updated papers length = %d, want 1", len(updated.Papers))
+	}
+	if updated.Papers[0].UUID != retainedPaperUUID {
+		t.Fatalf("remaining paper UUID = %q, want %q", updated.Papers[0].UUID, retainedPaperUUID)
+	}
+}
+
+func TestHandleStackPaperRemoveRejectsNonOwner(t *testing.T) {
+	t.Parallel()
+
+	stackService := newTestStackService()
+	owner := userDomain.NewUser("owner-paper-remove-forbidden", "owner-remove@example.com")
+	stack := stackDomain.NewStack("Forbidden Paper Remove Stack", owner)
+	paperUUID := "33333333-3333-4333-8333-333333333333"
+	stack.Papers = []paperDomain.Paper{{UUID: paperUUID, Title: "Kept Paper"}}
+	if err := stackService.Create(t.Context(), *stack); err != nil {
+		t.Fatalf("seed stack: %v", err)
+	}
+
+	handler := handleStackPaperRemove(testLogger(), testWebTemplate(t), stackService)
+	req := newStackPaperRemoveRequest(t, stack.UUID, paperUUID, "other-paper-remove-forbidden", "other-remove@example.com")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assertSidebarStackCreateError(t, rr, http.StatusOK, "You are not allowed to remove papers from this stack.")
+
+	updated, err := stackService.GetByUUID(req.Context(), stack.UUID)
+	if err != nil {
+		t.Fatalf("GetByUUID() error = %v", err)
+	}
+	if len(updated.Papers) != 1 {
+		t.Fatalf("updated papers length = %d, want unchanged 1", len(updated.Papers))
+	}
+}
+
 func TestHandleSidebarStackCreateRedirectsToDetail(t *testing.T) {
 	t.Parallel()
 
@@ -352,6 +423,22 @@ func newStackPublicSettingRequest(t *testing.T, stackUUID string, userID string,
 	req := httptest.NewRequest(http.MethodPost, "/app/stacks/detail/"+stackUUID+"/settings/is-public", strings.NewReader(values.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.SetPathValue("uuid", stackUUID)
+	req = req.WithContext(commonauth.ContextWithSession(req.Context(), &commonauth.Session{
+		UserID:  userID,
+		Email:   email,
+		IsValid: true,
+	}))
+
+	return req
+}
+
+func newStackPaperRemoveRequest(t *testing.T, stackUUID string, paperUUID string, userID string, email string) *http.Request {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/app/stacks/detail/"+stackUUID+"/papers/"+paperUUID+"/remove", nil)
+	req.Header.Set("HX-Request", "true")
+	req.SetPathValue("uuid", stackUUID)
+	req.SetPathValue("paperUUID", paperUUID)
 	req = req.WithContext(commonauth.ContextWithSession(req.Context(), &commonauth.Session{
 		UserID:  userID,
 		Email:   email,

--- a/backend/internal/web/routes.go
+++ b/backend/internal/web/routes.go
@@ -71,6 +71,7 @@ func AddRoute(
 	mux.Handle(http.MethodPost+" /stacks/detail/{uuid}/delete", authenticated(handleStackDelete(logger, tmpl, stackService)))
 	mux.Handle(http.MethodPost+" /stacks/detail/{uuid}/settings/is-public", authenticated(handleStackPublicSettingUpdate(logger, tmpl, stackService)))
 	mux.Handle(http.MethodGet+" /stacks/detail/{stackUUID}/papers/{paperUUID}", authenticated(handleStackPaperInfo(logger, tmpl, paperService)))
+	mux.Handle(http.MethodPost+" /stacks/detail/{uuid}/papers/{paperUUID}/remove", authenticated(handleStackPaperRemove(logger, tmpl, stackService)))
 	mux.Handle(http.MethodPost+" /stacks/search", defaultMiddle(handleStacksSearchByOwner(logger, tmpl, stackService)))
 	mux.Handle(http.MethodPost+" /stacks/stats", defaultMiddle(handleStacksStatsByOwner(logger, tmpl, stackService)))
 	mux.Handle(http.MethodPost+" /stacks/sidebar/create", authenticated(handleSidebarStackCreate(logger, tmpl, stackService)))

--- a/backend/internal/web/templates/pages/stacks/detail.html
+++ b/backend/internal/web/templates/pages/stacks/detail.html
@@ -6,8 +6,8 @@
       <ul>
         <li>
           <a
-            href="/app/stacks/my"
-            hx-get="/app/stacks/my"
+            href="/app/stacks/page"
+            hx-get="/app/stacks/page"
             hx-target="#page-shell"
             hx-select="#page-shell"
             hx-select-oob="#sidebar-menu:outerHTML"
@@ -146,7 +146,20 @@
                 <td>{{ range $i, $author := .Authors }}{{ if $i }}; {{ end }}{{ $author.FullName }}{{ end }}</td>
                 <td>{{ .PublicationYear }}</td>
                 <td class="text-right">
-                  <a class="btn btn-ghost btn-xs">PDF</a>
+                  <div class="flex">
+                    <a class="btn btn-ghost btn-xs">PDF</a>
+                    <button
+                      class="btn btn-ghost btn-xs"
+                      type="button"
+                      hx-post="/app/stacks/detail/{{ $.Stack.UUID }}/papers/{{ .UUID }}/remove"
+                      hx-target="#toast-host"
+                      hx-swap="innerHTML"
+                      hx-disabled-elt="this"
+                      hx-on::click="event.stopPropagation()"
+                    >
+                      Remove
+                    </button>
+                  </div>
                 </td>
               </tr>
               {{ end }}


### PR DESCRIPTION
This PR adds the functionality to the UI to remove a paper from the stack.
There is no confirmation dialog as the papers are not deleted.
After removing a paper the stack detail page is refreshed to update all information.