### PR TITLE
Set authenticated middleware for all web stack routes

### DIFF
--- a/backend/internal/web/routes.go
+++ b/backend/internal/web/routes.go
@@ -65,15 +65,15 @@ func AddRoute(
 	mux.Handle(http.MethodPost+" /papers/search", defaultMiddle(handlePapersSearch(logger, tmpl, paperService)))
 
 	stacksMyTmpl := pageTemplate("stacks/page")
-	mux.Handle(http.MethodGet+" /stacks/page", defaultMiddle(handleStacksPage(logger, stacksMyTmpl, cfg.HankoAPIURL, stackService)))
+	mux.Handle(http.MethodGet+" /stacks/page", authenticated(handleStacksPage(logger, stacksMyTmpl, cfg.HankoAPIURL, stackService)))
 	stacksDetailTmpl := pageTemplate("stacks/detail")
 	mux.Handle(http.MethodGet+" /stacks/detail/{uuid}", authenticated(handleStacksDetailPage(logger, stacksDetailTmpl, cfg.HankoAPIURL, stackService)))
 	mux.Handle(http.MethodPost+" /stacks/detail/{uuid}/delete", authenticated(handleStackDelete(logger, tmpl, stackService)))
 	mux.Handle(http.MethodPost+" /stacks/detail/{uuid}/settings/is-public", authenticated(handleStackPublicSettingUpdate(logger, tmpl, stackService)))
 	mux.Handle(http.MethodGet+" /stacks/detail/{stackUUID}/papers/{paperUUID}", authenticated(handleStackPaperInfo(logger, tmpl, paperService)))
 	mux.Handle(http.MethodPost+" /stacks/detail/{uuid}/papers/{paperUUID}/remove", authenticated(handleStackPaperRemove(logger, tmpl, stackService)))
-	mux.Handle(http.MethodPost+" /stacks/search", defaultMiddle(handleStacksSearchByOwner(logger, tmpl, stackService)))
-	mux.Handle(http.MethodPost+" /stacks/stats", defaultMiddle(handleStacksStatsByOwner(logger, tmpl, stackService)))
+	mux.Handle(http.MethodPost+" /stacks/search", authenticated(handleStacksSearchByOwner(logger, tmpl, stackService)))
+	mux.Handle(http.MethodPost+" /stacks/stats", authenticated(handleStacksStatsByOwner(logger, tmpl, stackService)))
 	mux.Handle(http.MethodPost+" /stacks/sidebar/create", authenticated(handleSidebarStackCreate(logger, tmpl, stackService)))
 
 	settingsTmpl := pageTemplate("settings/page")


### PR DESCRIPTION
This PR changes the middleware of all stack pages/partials to `authenticated` to ensure only authenticated users can navigate to the pages.