### PR TITLE
Added handling of data dumps.

### DIFF
--- a/backend/cmd/crawler/domain/metadata.go
+++ b/backend/cmd/crawler/domain/metadata.go
@@ -1,0 +1,172 @@
+// Package domain defines the domain model the crawler imports Crossref
+// works into. It mirrors the fields present in the Crossref public data
+// export (https://www.crossref.org/documentation/metadata-plus/) closely
+// enough to hold every record losslessly, while staying independent of the
+// raw JSON shape so parsing concerns stay out of it.
+package domain
+
+import "time"
+
+// Paper is a single Crossref "work" record — a journal article, book,
+// book chapter, or similar publication.
+type Paper struct {
+	// DOI is the Digital Object Identifier that uniquely identifies the
+	// work (e.g. "10.1006/jmcc.2000.1342"). Every record has one; it is
+	// the natural primary key for the import.
+	DOI string
+
+	// Type is the Crossref work type (e.g. "journal-article",
+	// "book-chapter", "book").
+	Type string
+
+	// Source identifies the metadata source as reported by Crossref
+	// (typically "Crossref").
+	Source string
+
+	Title               string
+	Subtitle            string
+	ContainerTitle      string // Journal, book, or proceedings title.
+	ShortContainerTitle string
+	Abstract            string // May contain embedded JATS XML markup.
+
+	Publisher         string
+	PublisherLocation string
+	Member            string // Crossref member ID of the depositing publisher.
+	Prefix            string // DOI prefix (e.g. "10.1006").
+
+	Language string
+	URL      string // Canonical resolver URL, usually "https://doi.org/<DOI>".
+
+	// ResourceURL is the primary full-text landing page URL, if reported.
+	ResourceURL string
+
+	Volume           string
+	Issue            string
+	Page             string
+	SpecialNumbering string
+
+	ISSNs []ISSN
+	ISBNs []ISBN
+
+	Authors    []Contributor
+	Editors    []Contributor
+	Funders    []Funder
+	References []Reference
+	Licenses   []License
+
+	// AlternativeIDs lists other identifiers publishers use for the same
+	// work (e.g. a publisher's internal article ID).
+	AlternativeIDs []string
+
+	Issued          PartialDate // Earliest known publication date.
+	Published       PartialDate
+	PublishedPrint  PartialDate
+	PublishedOnline PartialDate
+
+	Created   time.Time // When the DOI was first registered with Crossref.
+	Deposited time.Time // When this metadata version was deposited.
+	Indexed   time.Time // When Crossref last indexed this record.
+
+	// ReferenceCount and ReferencesCount both report the number of
+	// entries in References; Crossref exposes both names in its schema,
+	// so both are kept for fidelity with the source data.
+	ReferenceCount      int
+	ReferencesCount     int
+	IsReferencedByCount int // Number of works citing this one, per Crossref.
+}
+
+// ISSN is an International Standard Serial Number bound to a specific
+// medium (e.g. "print" or "electronic").
+type ISSN struct {
+	Value string
+	Type  string
+}
+
+// ISBN is an International Standard Book Number bound to a specific
+// medium (e.g. "print" or "electronic").
+type ISBN struct {
+	Value string
+	Type  string
+}
+
+// Contributor represents a person credited on a work, either as an
+// author or an editor.
+type Contributor struct {
+	GivenName    string
+	FamilyName   string
+	Sequence     string // "first" or "additional".
+	ORCID        string
+	Affiliations []string
+}
+
+// FullName returns the contributor's name assembled from its parts.
+func (c Contributor) FullName() string {
+	if c.GivenName == "" {
+		return c.FamilyName
+	}
+	if c.FamilyName == "" {
+		return c.GivenName
+	}
+	return c.GivenName + " " + c.FamilyName
+}
+
+// Funder represents a funding body credited for supporting the work.
+type Funder struct {
+	Name   string
+	DOI    string
+	Awards []string // Grant or award numbers attributed to this funder.
+}
+
+// Reference is a bibliographic reference cited by the work. DOI, and
+// often several other fields, may be empty for unstructured or
+// pre-DOI-era citations.
+type Reference struct {
+	Key          string
+	DOI          string
+	ArticleTitle string
+	Author       string
+	JournalTitle string
+	Volume       string
+	FirstPage    string
+	Year         string
+	Unstructured string // Free-text citation when structured fields are absent.
+}
+
+// License describes a usage license applicable to the work.
+type License struct {
+	URL            string
+	ContentVersion string
+	DelayInDays    int
+	Start          PartialDate
+}
+
+// PartialDate represents a Crossref "date-parts" style date, which may be
+// known only to year, year+month, or year+month+day precision. A
+// PartialDate with Year == 0 carries no date information.
+type PartialDate struct {
+	Year  int
+	Month int // 0 if unknown.
+	Day   int // 0 if unknown.
+}
+
+// IsZero reports whether the date carries no information.
+func (d PartialDate) IsZero() bool {
+	return d.Year == 0
+}
+
+// Time converts the date to a UTC time.Time, defaulting unknown month or
+// day components to 1. It returns the zero time.Time if IsZero is true.
+func (d PartialDate) Time() time.Time {
+	if d.IsZero() {
+		return time.Time{}
+	}
+	month := d.Month
+	if month == 0 {
+		month = 1
+	}
+	day := d.Day
+	if day == 0 {
+		day = 1
+	}
+	return time.Date(d.Year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
+}

--- a/backend/cmd/crawler/main.go
+++ b/backend/cmd/crawler/main.go
@@ -1,0 +1,123 @@
+// Command crawler imports Crossref public-data-export dump files
+// (*.jsonl or *.jsonl.gz) from a directory, parsing every record and
+// reporting import statistics.
+//
+// Usage:
+//
+//	go run ./cmd/crawler -dir /path/to/dump
+//
+// Persistence isn't wired up yet — this currently reports what would be
+// imported (record and error counts) without writing anywhere.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/paperstacks.io/paperstacks/cmd/crawler/reader"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	dir := flag.String("dir", "", "Directory containing *.jsonl[.gz] dump files (required)")
+	progressEvery := flag.Int("progress-every", 100_000, "Log a progress line every N records (0 disables)")
+	debug := flag.Bool("debug", false, "Enable debug logging")
+	flag.Parse()
+
+	if *dir == "" {
+		return fmt.Errorf("flag -dir is required")
+	}
+
+	level := slog.LevelInfo
+	if *debug {
+		level = slog.LevelDebug
+	}
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: level}))
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	log.Info("crawler import starting", slog.String("dir", *dir))
+	start := time.Now()
+
+	var totalFiles, totalRecords, totalErrors int
+
+	// importFile drains one dump file's records, tallying successes and
+	// per-line parse errors. A non-nil error means either the file
+	// couldn't be opened/decompressed, or the run was interrupted.
+	importFile := func(path string) (records, errs int, err error) {
+		ch, err := reader.ReadFile(path)
+		if err != nil {
+			return 0, 0, fmt.Errorf("open file: %w", err)
+		}
+
+		for rec := range ch {
+			if rec.Err != nil {
+				errs++
+				log.Warn("parse error",
+					slog.String("file", path),
+					slog.Int("line", rec.LineNumber),
+					slog.String("error", rec.Err.Error()),
+				)
+				continue
+			}
+
+			records++
+			totalRecords++
+			if *progressEvery > 0 && totalRecords%*progressEvery == 0 {
+				log.Info("progress", slog.Int("total_records", totalRecords))
+			}
+
+			if err := ctx.Err(); err != nil {
+				return records, errs, err
+			}
+		}
+
+		return records, errs, nil
+	}
+
+	walkErr := reader.WalkDumpDir(*dir, func(path string) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		fileRecords, fileErrors, err := importFile(path)
+		totalFiles++
+		totalErrors += fileErrors
+
+		if err != nil {
+			log.Error("file failed", slog.String("file", path), slog.String("error", err.Error()))
+			return ctx.Err()
+		}
+
+		log.Info("file complete",
+			slog.String("file", path),
+			slog.Int("records", fileRecords),
+			slog.Int("errors", fileErrors),
+			slog.Int("total_records", totalRecords),
+			slog.Duration("elapsed", time.Since(start)),
+		)
+		return nil
+	})
+
+	log.Info("import finished",
+		slog.Int("files", totalFiles),
+		slog.Int("records", totalRecords),
+		slog.Int("errors", totalErrors),
+		slog.Duration("elapsed", time.Since(start)),
+	)
+
+	return walkErr
+}

--- a/backend/cmd/crawler/parser/parser.go
+++ b/backend/cmd/crawler/parser/parser.go
@@ -1,0 +1,212 @@
+// Package parser decodes Crossref public-data-export JSON lines into the
+// crawler's domain model.
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/paperstacks.io/paperstacks/cmd/crawler/domain"
+)
+
+// Parse decodes a single JSON-encoded Crossref work record and converts
+// it into the crawler's domain model.
+//
+// Missing or malformed optional fields are silently skipped; Parse only
+// returns an error when the line can't be decoded as JSON at all, or the
+// record has no DOI, since the DOI is what the rest of the pipeline keys
+// on.
+func Parse(line []byte) (*domain.Paper, error) {
+	var raw rawRecord
+	if err := json.Unmarshal(line, &raw); err != nil {
+		return nil, fmt.Errorf("decode record: %w", err)
+	}
+
+	if raw.DOI == "" {
+		return nil, fmt.Errorf("record has no DOI")
+	}
+
+	p := &domain.Paper{
+		DOI:                 raw.DOI,
+		Type:                raw.Type,
+		Source:              raw.Source,
+		Title:               firstOf(raw.Title),
+		Subtitle:            firstOf(raw.Subtitle),
+		ContainerTitle:      firstOf(raw.ContainerTitle),
+		ShortContainerTitle: firstOf(raw.ShortContainerTitle),
+		Abstract:            raw.Abstract,
+		Publisher:           raw.Publisher,
+		PublisherLocation:   raw.PublisherLocation,
+		Member:              raw.Member,
+		Prefix:              raw.Prefix,
+		Language:            raw.Language,
+		URL:                 raw.URL,
+		ResourceURL:         raw.Resource.Primary.URL,
+		Volume:              raw.Volume,
+		Issue:               raw.Issue,
+		Page:                raw.Page,
+		SpecialNumbering:    raw.SpecialNumbering,
+		AlternativeIDs:      raw.AlternativeID,
+		ReferenceCount:      raw.ReferenceCount,
+		ReferencesCount:     raw.ReferencesCount,
+		IsReferencedByCount: raw.IsReferencedByCount,
+		Issued:              toPartialDate(raw.Issued),
+		Published:           toPartialDate(raw.Published),
+		PublishedPrint:      toPartialDate(raw.PublishedPrint),
+		PublishedOnline:     toPartialDate(raw.PublishedOnline),
+		Created:             toTime(raw.Created),
+		Deposited:           toTime(raw.Deposited),
+		Indexed:             toTime(raw.Indexed),
+		ISSNs:               toIdentifiers(raw.ISSN, raw.ISSNType),
+		ISBNs:               toISBNs(raw.ISBN, raw.ISBNType),
+		Authors:             toContributors(raw.Author),
+		Editors:             toContributors(raw.Editor),
+	}
+
+	for _, f := range raw.Funder {
+		p.Funders = append(p.Funders, domain.Funder{
+			Name:   f.Name,
+			DOI:    f.DOI,
+			Awards: f.Award,
+		})
+	}
+
+	for _, ref := range raw.Reference {
+		p.References = append(p.References, domain.Reference{
+			Key:          ref.Key,
+			DOI:          ref.DOI,
+			ArticleTitle: ref.ArticleTitle,
+			Author:       ref.Author,
+			JournalTitle: ref.JournalTitle,
+			Volume:       ref.Volume,
+			FirstPage:    ref.FirstPage,
+			Year:         ref.Year,
+			Unstructured: ref.Unstructured,
+		})
+	}
+
+	for _, lic := range raw.License {
+		p.Licenses = append(p.Licenses, domain.License{
+			URL:            lic.URL,
+			ContentVersion: lic.ContentVersion,
+			DelayInDays:    lic.DelayInDays,
+			Start:          toPartialDate(lic.Start),
+		})
+	}
+
+	return p, nil
+}
+
+// toIdentifiers merges a plain identifier list (e.g. "ISSN") with its
+// typed counterpart (e.g. "issn-type") into domain.ISSN values. The
+// typed list is preferred when present since it also carries the medium
+// (print/electronic); values only present in the plain list are kept
+// with an empty Type.
+func toIdentifiers(plain []string, typed []rawTypedID) []domain.ISSN {
+	if len(typed) == 0 {
+		out := make([]domain.ISSN, 0, len(plain))
+		for _, v := range plain {
+			out = append(out, domain.ISSN{Value: v})
+		}
+		return out
+	}
+
+	out := make([]domain.ISSN, 0, len(typed))
+	for _, t := range typed {
+		out = append(out, domain.ISSN{Value: t.Value, Type: t.Type})
+	}
+	return out
+}
+
+func toISBNs(plain []string, typed []rawTypedID) []domain.ISBN {
+	if len(typed) == 0 {
+		out := make([]domain.ISBN, 0, len(plain))
+		for _, v := range plain {
+			out = append(out, domain.ISBN{Value: v})
+		}
+		return out
+	}
+
+	out := make([]domain.ISBN, 0, len(typed))
+	for _, t := range typed {
+		out = append(out, domain.ISBN{Value: t.Value, Type: t.Type})
+	}
+	return out
+}
+
+func toContributors(raw []rawContributor) []domain.Contributor {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	out := make([]domain.Contributor, 0, len(raw))
+	for _, c := range raw {
+		contributor := domain.Contributor{
+			GivenName:  c.Given,
+			FamilyName: c.Family,
+			Sequence:   c.Sequence,
+			ORCID:      cleanORCID(c.ORCID),
+		}
+		for _, a := range c.Affiliation {
+			if a.Name != "" {
+				contributor.Affiliations = append(contributor.Affiliations, a.Name)
+			}
+		}
+		out = append(out, contributor)
+	}
+	return out
+}
+
+// toPartialDate extracts a domain.PartialDate from a rawDateField's
+// date-parts. Returns the zero value if no usable date-parts are present.
+func toPartialDate(f rawDateField) domain.PartialDate {
+	if len(f.DateParts) == 0 || len(f.DateParts[0]) == 0 {
+		return domain.PartialDate{}
+	}
+	parts := f.DateParts[0]
+	pd := domain.PartialDate{Year: parts[0]}
+	if len(parts) >= 2 {
+		pd.Month = parts[1]
+	}
+	if len(parts) >= 3 {
+		pd.Day = parts[2]
+	}
+	return pd
+}
+
+// toTime converts a rawDateField to a time.Time. Prefers the date-time
+// string, falls back to the millisecond timestamp, then to date-parts.
+// Returns the zero time.Time if nothing usable is available.
+func toTime(f rawDateField) time.Time {
+	if f.DateTime != "" {
+		if t, err := time.Parse(time.RFC3339, f.DateTime); err == nil {
+			return t
+		}
+	}
+	if f.Timestamp != nil {
+		return time.UnixMilli(*f.Timestamp).UTC()
+	}
+	return toPartialDate(f).Time()
+}
+
+// firstOf returns the first non-empty string from a slice, or "" if the
+// slice is empty. Crossref represents single-valued fields like "title"
+// as one-element arrays.
+func firstOf(ss []string) string {
+	for _, s := range ss {
+		if s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+// cleanORCID strips the common ORCID URL prefix so only the bare
+// identifier is stored (e.g. "0000-0002-1825-0097").
+func cleanORCID(raw string) string {
+	raw = strings.TrimPrefix(raw, "http://orcid.org/")
+	raw = strings.TrimPrefix(raw, "https://orcid.org/")
+	return raw
+}

--- a/backend/cmd/crawler/parser/raw.go
+++ b/backend/cmd/crawler/parser/raw.go
@@ -1,0 +1,107 @@
+package parser
+
+// rawRecord mirrors the JSON shape of a single Crossref "work" record as
+// found in the Crossref public data export. Field names follow the
+// export's schema; see https://api.crossref.org/swagger-ui/index.html
+// for the reference.
+type rawRecord struct {
+	DOI                 string           `json:"DOI"`
+	Type                string           `json:"type"`
+	Source              string           `json:"source"`
+	Title               []string         `json:"title"`
+	Subtitle            []string         `json:"subtitle"`
+	ContainerTitle      []string         `json:"container-title"`
+	ShortContainerTitle []string         `json:"short-container-title"`
+	Abstract            string           `json:"abstract"`
+	Publisher           string           `json:"publisher"`
+	PublisherLocation   string           `json:"publisher-location"`
+	Member              string           `json:"member"`
+	Prefix              string           `json:"prefix"`
+	Language            string           `json:"language"`
+	URL                 string           `json:"URL"`
+	Resource            rawResource      `json:"resource"`
+	Volume              string           `json:"volume"`
+	Issue               string           `json:"issue"`
+	Page                string           `json:"page"`
+	SpecialNumbering    string           `json:"special_numbering"`
+	ISSN                []string         `json:"ISSN"`
+	ISSNType            []rawTypedID     `json:"issn-type"`
+	ISBN                []string         `json:"ISBN"`
+	ISBNType            []rawTypedID     `json:"isbn-type"`
+	Author              []rawContributor `json:"author"`
+	Editor              []rawContributor `json:"editor"`
+	Funder              []rawFunder      `json:"funder"`
+	Reference           []rawReference   `json:"reference"`
+	License             []rawLicense     `json:"license"`
+	AlternativeID       []string         `json:"alternative-id"`
+	Issued              rawDateField     `json:"issued"`
+	Published           rawDateField     `json:"published"`
+	PublishedPrint      rawDateField     `json:"published-print"`
+	PublishedOnline     rawDateField     `json:"published-online"`
+	Created             rawDateField     `json:"created"`
+	Deposited           rawDateField     `json:"deposited"`
+	Indexed             rawDateField     `json:"indexed"`
+	ReferenceCount      int              `json:"reference-count"`
+	ReferencesCount     int              `json:"references-count"`
+	IsReferencedByCount int              `json:"is-referenced-by-count"`
+}
+
+type rawResource struct {
+	Primary struct {
+		URL string `json:"URL"`
+	} `json:"primary"`
+}
+
+// rawTypedID is a value bound to a medium type, used for both
+// "issn-type" and "isbn-type" entries (e.g. {"type": "print", "value": "..."}).
+type rawTypedID struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+type rawContributor struct {
+	Given       string           `json:"given"`
+	Family      string           `json:"family"`
+	Sequence    string           `json:"sequence"`
+	ORCID       string           `json:"ORCID"`
+	Affiliation []rawAffiliation `json:"affiliation"`
+}
+
+type rawAffiliation struct {
+	Name string `json:"name"`
+}
+
+type rawFunder struct {
+	Name  string   `json:"name"`
+	DOI   string   `json:"DOI"`
+	Award []string `json:"award"`
+}
+
+type rawReference struct {
+	Key          string `json:"key"`
+	DOI          string `json:"DOI"`
+	ArticleTitle string `json:"article-title"`
+	Author       string `json:"author"`
+	JournalTitle string `json:"journal-title"`
+	Volume       string `json:"volume"`
+	FirstPage    string `json:"first-page"`
+	Year         string `json:"year"`
+	Unstructured string `json:"unstructured"`
+}
+
+type rawLicense struct {
+	URL            string       `json:"URL"`
+	ContentVersion string       `json:"content-version"`
+	DelayInDays    int          `json:"delay-in-days"`
+	Start          rawDateField `json:"start"`
+}
+
+// rawDateField is Crossref's common date representation, used for
+// "issued", "published", "created", "deposited", "indexed" and similar
+// fields. DateParts holds [[year, month, day]] with trailing components
+// omitted when unknown.
+type rawDateField struct {
+	DateParts [][]int `json:"date-parts"`
+	DateTime  string  `json:"date-time"`
+	Timestamp *int64  `json:"timestamp"`
+}

--- a/backend/cmd/crawler/reader/reader.go
+++ b/backend/cmd/crawler/reader/reader.go
@@ -1,0 +1,122 @@
+// Package reader streams Crossref work records out of the annual public
+// data export: a directory of gzip-compressed JSONL files, one Crossref
+// "work" per line. It owns file-system traversal, gzip decompression and
+// line scanning; turning a line into the domain model is delegated to
+// the parser package.
+package reader
+
+import (
+	"bufio"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/paperstacks.io/paperstacks/cmd/crawler/domain"
+	"github.com/paperstacks.io/paperstacks/cmd/crawler/parser"
+)
+
+// Record wraps either a successfully parsed Paper or an error for one
+// line of a JSONL file. LineNumber helps with locating malformed input.
+type Record struct {
+	Paper      *domain.Paper
+	LineNumber int
+	Err        error
+}
+
+// ReadFile opens a single .jsonl or .jsonl.gz file and sends each parsed
+// record to the returned channel. The channel is closed once every line
+// has been processed or a fatal I/O error occurs.
+//
+// Errors for individual malformed lines are reported as Record.Err
+// entries and do not abort the file; a fatal I/O error (e.g. a truncated
+// gzip stream) is sent as a final Record with a nil Paper, after which
+// the channel is closed.
+func ReadFile(path string) (<-chan Record, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", path, err)
+	}
+
+	var r io.Reader = f
+	if isGzip(path) {
+		gz, err := gzip.NewReader(f)
+		if err != nil {
+			f.Close()
+			return nil, fmt.Errorf("open gzip stream %s: %w", path, err)
+		}
+		r = gz
+	}
+
+	out := make(chan Record, 256) // buffered to decouple I/O from downstream processing
+
+	go func() {
+		defer f.Close()
+		defer close(out)
+
+		scanner := bufio.NewScanner(r)
+		// Crossref records — especially ones with long reference lists —
+		// can exceed the scanner's 64 KB default token size.
+		const maxTokenSize = 16 * 1024 * 1024
+		scanner.Buffer(make([]byte, 64*1024), maxTokenSize)
+
+		lineNum := 0
+		for scanner.Scan() {
+			lineNum++
+			line := scanner.Bytes()
+			if len(line) == 0 {
+				continue
+			}
+
+			paper, err := parser.Parse(line)
+			if err != nil {
+				out <- Record{LineNumber: lineNum, Err: fmt.Errorf("line %d: %w", lineNum, err)}
+				continue
+			}
+			out <- Record{Paper: paper, LineNumber: lineNum}
+		}
+
+		if err := scanner.Err(); err != nil {
+			out <- Record{Err: fmt.Errorf("scan %s: %w", path, err)}
+		}
+	}()
+
+	return out, nil
+}
+
+// WalkDumpDir walks dir for Crossref dump files (named e.g. 0.jsonl.gz,
+// 1.jsonl.gz, …) and calls fn once per file, in lexicographic file-name
+// order. Only *.jsonl and *.jsonl.gz files are visited; fn is not called
+// for anything else.
+func WalkDumpDir(dir string, fn func(path string) error) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("read directory %s: %w", dir, err)
+	}
+
+	var names []string
+	for _, e := range entries {
+		if !e.IsDir() && isDumpFile(e.Name()) {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		if err := fn(filepath.Join(dir, name)); err != nil {
+			return fmt.Errorf("processing %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func isGzip(path string) bool {
+	return strings.HasSuffix(path, ".gz")
+}
+
+func isDumpFile(name string) bool {
+	return strings.HasSuffix(name, ".jsonl") || strings.HasSuffix(name, ".jsonl.gz")
+}


### PR DESCRIPTION
This part of the crawler can be used to traverse the yearly data dump from Crossref. 
The data dump consists of roughly 35000 jsonl.gz files each containing several thousands of metadata entries. 

execution:  go run ./path/to/main.go -dir <dir>. 

main.go is the entrypoint. -dir flag has to be provided by the user when calling via terminal. 
/domain/metadata.go is the internal domain model containing all possible metadata fields for a paper as well as structs for references or partial dates. 
/reader/reader.go traverses all files from the provided directory
/parser/raw.go maps all json fields from the crossref export to a rawrecord attribute
/parser/parser.go maps a rawrecord to the intenal domain model (metadata.go paper struct)

so far there is no logic for database access. this comes in a later pr.