### PR TITLE
[Paper]: Introduce ISSN to paper metadata

### DIFF
--- a/backend/internal/integration/paper_integration_test.go
+++ b/backend/internal/integration/paper_integration_test.go
@@ -4,6 +4,7 @@ package integration
 import (
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -250,6 +251,9 @@ func TestIntegrationSavePaper(t *testing.T) {
 		Title:           "Test article",
 		PublicationDate: paperHttp.PublicationDate{Year: 2026, Month: 8, Day: 13},
 		Type:            "journal-article",
+		Metadata: paperHttp.MetadataRequest{
+			ISSN: []string{" 1234-5678 ", "8765-4321"},
+		},
 	}
 	endpoint := testAPIPath + "/api/papers"
 	resp := doPostRequest(t, endpoint, paper)
@@ -273,5 +277,9 @@ func TestIntegrationSavePaper(t *testing.T) {
 
 	if created.Type != paper.Type {
 		t.Fatalf("created publication type = %q, want %q", created.Type, paper.Type)
+	}
+
+	if got, want := created.Metadata.ISSN, []string{"1234-5678", "8765-4321"}; !slices.Equal(got, want) {
+		t.Fatalf("created ISSN = %q, want %q", got, want)
 	}
 }

--- a/backend/internal/paper/domain/metadata.go
+++ b/backend/internal/paper/domain/metadata.go
@@ -5,8 +5,8 @@ import "strings"
 // Metadata contains bibliographic and provenance information
 // describing where and how a publication was published.
 //
-// It includes identifiers such as DOI and ISBN, publication
-// details like volume and issue, licensing information, and
+// It includes identifiers such as DOI, ISBN, and ISSN, publication
+// details like volume and issue, licensing information, and provenance
 // metadata about the source from which this information was
 // retrieved (e.g., CrossRef or IEEE).
 type Metadata struct {
@@ -31,6 +31,10 @@ type Metadata struct {
 	// ISBN lists International Standard Book Numbers associated
 	// with the publication, typically used for books or proceedings.
 	ISBN []string
+
+	// ISSN lists International Standard Serial Numbers associated with
+	// journal and other serial publications.
+	ISSN []string
 
 	// References contains external references related to the work,
 	// typically URLs or URIs pointing to additional resources.
@@ -71,6 +75,10 @@ func (m Metadata) Normalize() Metadata {
 
 	for i := range m.ISBN {
 		m.ISBN[i] = strings.TrimSpace(m.ISBN[i])
+	}
+
+	for i := range m.ISSN {
+		m.ISSN[i] = strings.TrimSpace(m.ISSN[i])
 	}
 
 	for i := range m.References {

--- a/backend/internal/paper/domain/metadata_test.go
+++ b/backend/internal/paper/domain/metadata_test.go
@@ -1,0 +1,21 @@
+package domain
+
+import "testing"
+
+func TestMetadataNormalizeTrimsISSN(t *testing.T) {
+	t.Parallel()
+
+	got := (Metadata{
+		ISSN: []string{" 1234-5678 ", " 8765-4321 "},
+	}).Normalize()
+	want := []string{"1234-5678", "8765-4321"}
+
+	if len(got.ISSN) != len(want) {
+		t.Fatalf("normalized ISSN length = %d, want %d", len(got.ISSN), len(want))
+	}
+	for i := range want {
+		if got.ISSN[i] != want[i] {
+			t.Fatalf("normalized ISSN[%d] = %q, want %q", i, got.ISSN[i], want[i])
+		}
+	}
+}

--- a/backend/internal/paper/http/dto.go
+++ b/backend/internal/paper/http/dto.go
@@ -63,6 +63,7 @@ type MetadataRequest struct {
 	Volume              string   `json:"volume"`
 	Issue               string   `json:"issue"`
 	ISBN                []string `json:"ISBN"`
+	ISSN                []string `json:"ISSN"`
 	References          []string `json:"references"`
 	License             string   `json:"license"`
 	Copyright           string   `json:"copyright"`
@@ -78,6 +79,7 @@ type MetadataResponse struct {
 	Volume              string   `json:"volume"`
 	Issue               string   `json:"issue"`
 	ISBN                []string `json:"ISBN"`
+	ISSN                []string `json:"ISSN"`
 	References          []string `json:"references"`
 	License             string   `json:"license"`
 	Copyright           string   `json:"copyright"`
@@ -185,6 +187,7 @@ func (r MetadataRequest) toDomain() domain.Metadata {
 		Volume:              r.Volume,
 		Issue:               r.Issue,
 		ISBN:                r.ISBN,
+		ISSN:                r.ISSN,
 		References:          r.References,
 		License:             r.License,
 		Copyright:           r.Copyright,
@@ -202,6 +205,7 @@ func NewMetadataResponse(m domain.Metadata) MetadataResponse {
 		Volume:              m.Volume,
 		Issue:               m.Issue,
 		ISBN:                m.ISBN,
+		ISSN:                m.ISSN,
 		References:          m.References,
 		License:             m.License,
 		Copyright:           m.Copyright,

--- a/backend/internal/stack/http/dto.go
+++ b/backend/internal/stack/http/dto.go
@@ -103,6 +103,7 @@ type MetadataRequest struct {
 	Volume              string   `json:"volume"`
 	Issue               string   `json:"issue"`
 	ISBN                []string `json:"isbn"`
+	ISSN                []string `json:"issn"`
 	References          []string `json:"references"`
 	License             string   `json:"license"`
 	Copyright           string   `json:"copyright"`
@@ -118,6 +119,7 @@ type MetadataResponse struct {
 	Volume              string   `json:"volume"`
 	Issue               string   `json:"issue"`
 	ISBN                []string `json:"isbn"`
+	ISSN                []string `json:"issn"`
 	References          []string `json:"references"`
 	License             string   `json:"license"`
 	Copyright           string   `json:"copyright"`
@@ -290,6 +292,7 @@ func (m MetadataRequest) toDomain() paperDomain.Metadata {
 		Volume:              m.Volume,
 		Issue:               m.Issue,
 		ISBN:                m.ISBN,
+		ISSN:                m.ISSN,
 		References:          m.References,
 		License:             m.License,
 		Copyright:           m.Copyright,
@@ -307,6 +310,7 @@ func NewMetadataResponse(metadata paperDomain.Metadata) MetadataResponse {
 		Volume:              metadata.Volume,
 		Issue:               metadata.Issue,
 		ISBN:                metadata.ISBN,
+		ISSN:                metadata.ISSN,
 		References:          metadata.References,
 		License:             metadata.License,
 		Copyright:           metadata.Copyright,

--- a/db/init-scripts/002_init_database.sql
+++ b/db/init-scripts/002_init_database.sql
@@ -173,6 +173,7 @@ CREATE TABLE public.metadata (
 	datasource_timestamp timestamptz,
 	reference text[],
 	isbn text[],
+	issn text[],
 	pages smallint,
 	license text,
 	copyright text,
@@ -180,7 +181,6 @@ CREATE TABLE public.metadata (
 	uuid_paper uuid NOT NULL,
 	CONSTRAINT metadata_pk PRIMARY KEY (key)
 );
-
 COMMENT ON COLUMN public.metadata.volume IS E'volume of publication';
 COMMENT ON COLUMN public.metadata.issue IS E'issue of publication';
 COMMENT ON COLUMN public.metadata.datasource IS E'url of datasource';


### PR DESCRIPTION
This PR adds `ISSN` to paper metadata.

## Problem

Paper metadata supports ISBNs but cannot represent International Standard Serial
Numbers (ISSNs) for journals and other serial publications. That prevents
preserving print and electronic serial identifiers needed for complete journal
metadata and future CSL/BibLaTeX mappings.

## Change

Add `ISSN []string` to `domain.Metadata`.

The slice preserves multiple identifiers, including distinct print and
electronic ISSNs. Metadata normalization trims each ISSN while preserving order.

Expose the field through existing metadata contracts:

- Paper API: `metadata.ISSN`
- Stack API: `metadata.issn`
- PostgreSQL initialization schema: `public.metadata.issn text[]`